### PR TITLE
Richer phase/task flow + mobile-first UI refresh

### DIFF
--- a/server/defaultState.js
+++ b/server/defaultState.js
@@ -10,18 +10,17 @@ export function buildDefaultState() {
         name: 'Morning',
         defaultMinutes: 180,
         tasks: [
-          { id: 'task-1', title: 'Wake-up routine', done: false, minutes: 15 },
-          { id: 'task-2', title: 'Review top 3 priorities', done: false, minutes: 10 },
-          { id: 'task-3', title: 'Deep work block', done: false, minutes: 45 },
+          { id: 'task-1', title: 'Body scan + quiet input block', done: false, minutes: 25 },
+          { id: 'task-2', title: 'Capture and organize priorities', done: false, minutes: 10 },
         ],
       },
       {
         id: 'phase-2',
         name: 'Afternoon',
-        defaultMinutes: 240,
+        defaultMinutes: 180,
         tasks: [
-          { id: 'task-4', title: 'Admin cleanup', done: false, minutes: 20 },
-          { id: 'task-5', title: 'Errands or outreach', done: false, minutes: null },
+          { id: 'task-3', title: 'Deep work / writing block', done: false, minutes: 50 },
+          { id: 'task-4', title: 'Admin and recovery transitions', done: false, minutes: 20 },
         ],
       },
       {
@@ -29,13 +28,14 @@ export function buildDefaultState() {
         name: 'Evening',
         defaultMinutes: 180,
         tasks: [
-          { id: 'task-6', title: 'Reset space', done: false, minutes: 15 },
-          { id: 'task-7', title: 'Wind-down routine', done: false, minutes: 30 },
+          { id: 'task-5', title: 'System review and reset', done: false, minutes: 15 },
+          { id: 'task-6', title: 'Wind-down routine', done: false, minutes: 30 },
         ],
       },
     ],
     activePhaseId: 'phase-1',
     healthState: 'steady',
+    routineType: 'session',
     preferences: {
       setupComplete: false,
       timeZone: 'UTC',
@@ -84,6 +84,7 @@ export function normalizeState(input) {
       ? input.activePhaseId
       : firstPhaseId,
     healthState: HEALTH_OPTIONS.includes(input.healthState) ? input.healthState : fallback.healthState,
+    routineType: input.routineType === 'integration' ? 'integration' : 'session',
     preferences: {
       setupComplete: Boolean(input.preferences?.setupComplete),
       timeZone:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,67 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import calmBanner from './assets/calm-banner.svg';
 
 const HEALTH_OPTIONS = [
-  {
-    key: 'steady',
-    label: 'Steady',
-    guidance: 'Keep your current sequence and start with one quick win.',
-  },
-  {
-    key: 'scattered',
-    label: 'Scattered',
-    guidance: 'Shrink scope to your top three tasks and use shorter timed blocks.',
-  },
-  {
-    key: 'drained',
-    label: 'Drained',
-    guidance: 'Lean on low-friction tasks, hydrate, and reduce decision load.',
-  },
+  { key: 'steady', label: 'Steady', guidance: 'Keep momentum with one clear next step and low friction.' },
+  { key: 'scattered', label: 'Scattered', guidance: 'Shrink scope and use shorter timed blocks with visible boundaries.' },
+  { key: 'drained', label: 'Drained', guidance: 'Choose lighter tasks, reduce transitions, and protect recovery.' },
 ];
+
+const ROUTINE_OPTIONS = [
+  { key: 'session', label: 'Session Day', note: 'Full rhythm with generative work and structured recovery blocks.' },
+  { key: 'integration', label: 'Integration Day', note: 'Lighter rhythm for regulation, review, and maintenance.' },
+];
+
+const TASK_LIBRARY = {
+  session: {
+    morning: [
+      { title: 'Body scan + jaw check', minutes: 3 },
+      { title: 'Phase 1 input reading', minutes: 25 },
+      { title: 'Capture ideas in notebook', minutes: 10 },
+      { title: 'Spanish primer', minutes: 20 },
+    ],
+    afternoon: [
+      { title: 'Deep writing block (Draft or Revise)', minutes: 50 },
+      { title: 'Admin and logistics sweep', minutes: 20 },
+      { title: 'Rehab movement set', minutes: 30 },
+      { title: 'Reading as writer', minutes: 25 },
+    ],
+    evening: [
+      { title: 'System review and tomorrow setup', minutes: 15 },
+      { title: 'Low-stakes study or reading', minutes: 25 },
+      { title: 'Wind-down routine', minutes: 30 },
+    ],
+    custom: [
+      { title: 'Define one clear outcome for this phase', minutes: 10 },
+      { title: 'Focused block', minutes: 30 },
+      { title: 'Reset and transition', minutes: 10 },
+    ],
+  },
+  integration: {
+    morning: [
+      { title: 'Morning regulation block', minutes: 15 },
+      { title: 'Gentle reading / input', minutes: 20 },
+      { title: 'Capture one sentence', minutes: 5 },
+      { title: 'Spanish light touch', minutes: 15 },
+    ],
+    afternoon: [
+      { title: 'Compost existing notes', minutes: 20 },
+      { title: 'Lower-load writing touch', minutes: 25 },
+      { title: 'Toe lifts / textured surface', minutes: 10 },
+      { title: 'Restorative break', minutes: 15 },
+    ],
+    evening: [
+      { title: 'Flare protocol check-in', minutes: 10 },
+      { title: 'Light planning for next day', minutes: 10 },
+      { title: 'Wind-down and settle', minutes: 25 },
+    ],
+    custom: [
+      { title: 'Reduce scope to one meaningful action', minutes: 10 },
+      { title: 'Easy maintenance task', minutes: 20 },
+      { title: 'Recovery break', minutes: 10 },
+    ],
+  },
+};
 
 const DEFAULT_SETTINGS = {
   phases: [
@@ -25,18 +70,17 @@ const DEFAULT_SETTINGS = {
       name: 'Morning',
       defaultMinutes: 180,
       tasks: [
-        { id: 'task-1', title: 'Wake-up routine', done: false, minutes: 15 },
-        { id: 'task-2', title: 'Review top 3 priorities', done: false, minutes: 10 },
-        { id: 'task-3', title: 'Deep work block', done: false, minutes: 45 },
+        { id: 'task-1', title: 'Body scan + quiet input block', done: false, minutes: 25 },
+        { id: 'task-2', title: 'Capture and organize priorities', done: false, minutes: 10 },
       ],
     },
     {
       id: 'phase-2',
       name: 'Afternoon',
-      defaultMinutes: 240,
+      defaultMinutes: 180,
       tasks: [
-        { id: 'task-4', title: 'Admin cleanup', done: false, minutes: 20 },
-        { id: 'task-5', title: 'Errands or outreach', done: false, minutes: null },
+        { id: 'task-3', title: 'Deep work / writing block', done: false, minutes: 50 },
+        { id: 'task-4', title: 'Admin and recovery transitions', done: false, minutes: 20 },
       ],
     },
     {
@@ -44,13 +88,14 @@ const DEFAULT_SETTINGS = {
       name: 'Evening',
       defaultMinutes: 180,
       tasks: [
-        { id: 'task-6', title: 'Reset space', done: false, minutes: 15 },
-        { id: 'task-7', title: 'Wind-down routine', done: false, minutes: 30 },
+        { id: 'task-5', title: 'System review and reset', done: false, minutes: 15 },
+        { id: 'task-6', title: 'Wind-down routine', done: false, minutes: 30 },
       ],
     },
   ],
   activePhaseId: 'phase-1',
   healthState: 'steady',
+  routineType: 'session',
   preferences: {
     setupComplete: false,
     timeZone: 'UTC',
@@ -89,6 +134,26 @@ function firstName(displayName) {
   return String(displayName ?? '').trim().split(/\s+/)[0] || 'there';
 }
 
+function getPhaseKey(name) {
+  const normalized = String(name || '').toLowerCase();
+  if (normalized.includes('morning')) {
+    return 'morning';
+  }
+  if (normalized.includes('afternoon') || normalized.includes('midday')) {
+    return 'afternoon';
+  }
+  if (normalized.includes('evening') || normalized.includes('night')) {
+    return 'evening';
+  }
+  return 'custom';
+}
+
+function getSuggestions(routineType, phaseName) {
+  const key = getPhaseKey(phaseName);
+  const type = routineType === 'integration' ? 'integration' : 'session';
+  return TASK_LIBRARY[type][key] ?? TASK_LIBRARY[type].custom;
+}
+
 function formatClockFromIso(iso, timeZone) {
   if (!iso) {
     return 'n/a';
@@ -107,33 +172,30 @@ function formatClockFromIso(iso, timeZone) {
 
 function cognitionTip(period, healthState) {
   const base = {
-    morning:
-      'Morning is usually best for initiation, planning, and high-focus work in ADHD when possible.',
-    afternoon:
-      'Afternoon often benefits from structure and external cues. Use timers and clear task boundaries.',
-    evening:
-      'Evening is often better for review, reset, and lower-friction tasks over heavy cognitive load.',
-  }[period] ?? 'Use smaller steps and clear cues to protect momentum.';
+    morning: 'Morning is best for planning and initiation. Keep early wins small and clear.',
+    afternoon: 'Afternoon often benefits from structure. Use visible task boundaries and timed focus blocks.',
+    evening: 'Evening works best for review, consolidation, and low-friction tasks.',
+  }[period] ?? 'Use smaller steps and external cues to protect momentum.';
 
   if (healthState === 'scattered') {
-    return `${base} If attention is fragmented, keep your next step under 10 minutes.`;
+    return `${base} For scattered attention, cap each step to 10 minutes.`;
   }
   if (healthState === 'drained') {
-    return `${base} If energy is low, choose maintenance tasks and lower transition costs.`;
+    return `${base} If energy is low, prioritize maintenance over expansion.`;
   }
   return base;
 }
 
 function greetingFor(period, phaseName, name) {
-  const map = {
+  if (String(phaseName).toLowerCase().includes('morning')) {
+    return `Good morning, ${name}.`;
+  }
+  const byPeriod = {
     morning: `Good morning, ${name}.`,
     afternoon: `Good afternoon, ${name}.`,
     evening: `Good evening, ${name}.`,
   };
-  if (String(phaseName).toLowerCase().includes('morning')) {
-    return `Good morning, ${name}.`;
-  }
-  return map[period] ?? `Hi ${name}.`;
+  return byPeriod[period] ?? `Hi ${name}.`;
 }
 
 async function api(path, options = {}) {
@@ -163,25 +225,17 @@ function AuthScreen({ mode, form, onModeChange, onChange, onSubmit, authPending,
       <section className="auth-card">
         <div>
           <p className="eyebrow">Focus Flow</p>
-          <h1>Account-based local testing</h1>
+          <h1>Sign in to your rhythm</h1>
           <p className="lede">
-            Create an account so your phases, routines, and setup are saved in the local app database.
+            Your phase setup, routines, and mind-check context are saved to your local account.
           </p>
         </div>
 
         <div className="auth-toggle">
-          <button
-            className={mode === 'login' ? 'active-tab' : 'ghost'}
-            onClick={() => onModeChange('login')}
-            type="button"
-          >
+          <button className={mode === 'login' ? 'active-tab' : 'ghost'} onClick={() => onModeChange('login')} type="button">
             Sign in
           </button>
-          <button
-            className={mode === 'register' ? 'active-tab' : 'ghost'}
-            onClick={() => onModeChange('register')}
-            type="button"
-          >
+          <button className={mode === 'register' ? 'active-tab' : 'ghost'} onClick={() => onModeChange('register')} type="button">
             Create account
           </button>
         </div>
@@ -190,28 +244,13 @@ function AuthScreen({ mode, form, onModeChange, onChange, onSubmit, authPending,
           {mode === 'register' && (
             <label>
               Name
-              <input
-                name="displayName"
-                value={form.displayName}
-                onChange={onChange}
-                placeholder="Alex"
-                autoComplete="name"
-              />
+              <input name="displayName" value={form.displayName} onChange={onChange} placeholder="Alex" autoComplete="name" />
             </label>
           )}
-
           <label>
             Email
-            <input
-              name="email"
-              type="email"
-              value={form.email}
-              onChange={onChange}
-              placeholder="alex@example.com"
-              autoComplete="email"
-            />
+            <input name="email" type="email" value={form.email} onChange={onChange} placeholder="alex@example.com" autoComplete="email" />
           </label>
-
           <label>
             Password
             <input
@@ -223,9 +262,7 @@ function AuthScreen({ mode, form, onModeChange, onChange, onSubmit, authPending,
               autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
             />
           </label>
-
           {authError && <p className="status-message error">{authError}</p>}
-
           <button type="submit" disabled={authPending}>
             {authPending ? 'Working...' : mode === 'login' ? 'Sign in' : 'Create account'}
           </button>
@@ -282,6 +319,10 @@ export default function App() {
   }, [activePhase]);
 
   const recommendation = HEALTH_OPTIONS.find((option) => option.key === settings.healthState)?.guidance;
+  const activeSuggestions = useMemo(
+    () => getSuggestions(settings.routineType, activePhase?.name),
+    [settings.routineType, activePhase?.name]
+  );
 
   useEffect(() => {
     function onDocumentClick(event) {
@@ -501,16 +542,6 @@ export default function App() {
     }));
   }
 
-  function setPreferencesPatch(patch) {
-    setSettings((current) => ({
-      ...current,
-      preferences: {
-        ...(current.preferences ?? {}),
-        ...patch,
-      },
-    }));
-  }
-
   async function handleAuthSubmit(event) {
     event.preventDefault();
     setAuthPending(true);
@@ -538,7 +569,7 @@ export default function App() {
     try {
       await api('/api/auth/logout', { method: 'POST' });
     } catch {
-      // no-op
+      // ignore
     }
     loadedSettingsRef.current = false;
     setUser(null);
@@ -580,12 +611,24 @@ export default function App() {
       return;
     }
     const parsedMinutes = Number(taskMinutesInput);
-    updateTasks((tasks) => [
-      ...tasks,
-      createTask(title, Number.isFinite(parsedMinutes) && parsedMinutes > 0 ? parsedMinutes : null),
-    ]);
+    updateTasks((tasks) => [...tasks, createTask(title, Number.isFinite(parsedMinutes) && parsedMinutes > 0 ? parsedMinutes : null)]);
     setTaskTitleInput('');
     setTaskMinutesInput('');
+  }
+
+  function addSuggestionTask(suggestion) {
+    updateTasks((tasks) => [...tasks, createTask(suggestion.title, suggestion.minutes ?? null)]);
+  }
+
+  function applyRoutineTemplate(nextType) {
+    setSettings((current) => ({
+      ...current,
+      routineType: nextType,
+      phases: current.phases.map((phase) => ({
+        ...phase,
+        tasks: getSuggestions(nextType, phase.name).slice(0, 4).map((task) => createTask(task.title, task.minutes)),
+      })),
+    }));
   }
 
   function insertPhaseAt(index) {
@@ -596,7 +639,7 @@ export default function App() {
         id: `phase-${crypto.randomUUID()}`,
         name: `Phase ${nextNumber}`,
         defaultMinutes: 90,
-        tasks: [createTask('First step', 10)],
+        tasks: getSuggestions(current.routineType, 'custom').map((task) => createTask(task.title, task.minutes)),
       };
       const phases = [...current.phases];
       phases.splice(safeIndex, 0, nextPhase);
@@ -636,11 +679,9 @@ export default function App() {
       const minutes = Number(setupDraft[phase.id]);
       return {
         ...phase,
-        defaultMinutes:
-          Number.isFinite(minutes) && minutes > 0 ? minutes : phase.defaultMinutes,
+        defaultMinutes: Number.isFinite(minutes) && minutes > 0 ? minutes : phase.defaultMinutes,
       };
     });
-
     setSettings((current) => ({
       ...current,
       phases: normalized,
@@ -660,37 +701,25 @@ export default function App() {
     }
     setSettings((current) => ({
       ...current,
-      phases: current.phases.map((phase) =>
-        phase.id === phaseId ? { ...phase, defaultMinutes: minutes } : phase
-      ),
+      phases: current.phases.map((phase) => (phase.id === phaseId ? { ...phase, defaultMinutes: minutes } : phase)),
     }));
   }
 
   function updatePhaseName(phaseId, nextName) {
     setSettings((current) => ({
       ...current,
-      phases: current.phases.map((phase) =>
-        phase.id === phaseId ? { ...phase, name: nextName } : phase
-      ),
+      phases: current.phases.map((phase) => (phase.id === phaseId ? { ...phase, name: nextName } : phase)),
     }));
   }
 
   function suggestNextAction() {
     const nextTask = activePhase.tasks.find((task) => !task.done);
     if (!nextTask) {
-      setMindAction('You are done with this phase. Take a short reset before moving on.');
+      setMindAction('This phase is complete. Take a short reset before switching context.');
       return;
     }
-
-    const durationHint = nextTask.minutes
-      ? `${nextTask.minutes} minutes`
-      : settings.healthState === 'scattered'
-        ? '10 minutes'
-        : '20 minutes';
-
-    setMindAction(
-      `Start "${nextTask.title}" now for ${durationHint}. Remove distractions and aim for one clean completion.`
-    );
+    const durationHint = nextTask.minutes ? `${nextTask.minutes} minutes` : settings.healthState === 'scattered' ? '10 minutes' : '20 minutes';
+    setMindAction(`Start "${nextTask.title}" now for ${durationHint}. Keep distractions out until it is done.`);
   }
 
   function refreshContext() {
@@ -774,21 +803,18 @@ export default function App() {
   return (
     <div className="app-shell">
       <aside className="sidebar">
+        <img src={calmBanner} alt="Calming landscape banner" className="calm-banner" />
         <div>
           <p className="eyebrow">Focus Flow</p>
-          <h1>ADHD-friendly day planning</h1>
-          <p className="lede">
-            Signed in as {user.displayName}. Save status: {saveStatus}
-          </p>
+          <h1>Daily rhythm dashboard</h1>
+          <p className="lede">Signed in as {user.displayName}. Save status: {saveStatus}</p>
         </div>
 
         {!settings.preferences?.setupComplete && (
           <section className="card setup-card">
             <p className="card-label">First login setup</p>
-            <h3>Set your default phase durations</h3>
-            <p className="lede">
-              Confirm your baseline durations here once. You can edit them later in Settings.
-            </p>
+            <h3>Set initial phase durations</h3>
+            <p className="lede">These are setup values only. Ongoing defaults live in Settings.</p>
             <div className="setup-grid">
               {settings.phases.map((phase) => (
                 <label key={phase.id}>
@@ -807,30 +833,37 @@ export default function App() {
                 </label>
               ))}
             </div>
-            <button onClick={completeFirstSetup}>Save defaults</button>
+            <button onClick={completeFirstSetup}>Save setup</button>
           </section>
         )}
 
         <div className="phase-list">
-          {settings.phases.map((phase) => (
-            <button
-              key={phase.id}
-              className={`phase-chip ${phase.id === settings.activePhaseId ? 'active' : ''}`}
-              onClick={() => setSettingsPatch({ activePhaseId: phase.id })}
-            >
-              <span>{phase.name}</span>
-              <small>{phase.defaultMinutes} min default</small>
-            </button>
-          ))}
+          {settings.phases.map((phase) => {
+            const openTasks = phase.tasks.filter((task) => !task.done).length;
+            return (
+              <button
+                key={phase.id}
+                className={`phase-chip ${phase.id === settings.activePhaseId ? 'active' : ''}`}
+                onClick={() => setSettingsPatch({ activePhaseId: phase.id })}
+              >
+                <span>{phase.name}</span>
+                <small>{openTasks} open tasks</small>
+              </button>
+            );
+          })}
         </div>
 
         <div className="card nav-note-card">
-          <p className="card-label">Phase editing</p>
-          <p className="muted-copy">Need a phase in the middle or a rename? Use Settings from the top-right menu.</p>
+          <p className="card-label">Navigation</p>
+          <p className="muted-copy">Need to adjust phase structure? Open Settings.</p>
+          <div className="button-row">
+            <button className="ghost small" onClick={() => setSiteView('settings')}>Open settings</button>
+            <button className="ghost small" onClick={() => setSiteView('profile')}>Open profile</button>
+          </div>
         </div>
 
         <div className="card accent-card">
-          <p className="card-label">Phase progress</p>
+          <p className="card-label">Progress</p>
           <strong>{Math.round(completionRatio * 100)}% complete</strong>
           <div className="progress-track" aria-hidden="true">
             <div className="progress-fill" style={{ width: `${completionRatio * 100}%` }} />
@@ -880,9 +913,7 @@ export default function App() {
             <p className="card-label">Profile</p>
             <h3>{user.displayName}</h3>
             <p className="muted-copy">{user.email}</p>
-            <p className="muted-copy">
-              Timezone: {settings.preferences?.timeZone || 'UTC'}
-            </p>
+            <p className="muted-copy">Timezone: {settings.preferences?.timeZone || 'UTC'}</p>
             <p className="muted-copy">
               Location:{' '}
               {settings.preferences?.location
@@ -900,10 +931,21 @@ export default function App() {
         {siteView === 'settings' && (
           <section className="card">
             <p className="card-label">Settings</p>
-            <h3>Default phase durations</h3>
-            <p className="muted-copy">
-              Insert phases anywhere, rename them, and update duration defaults.
-            </p>
+            <h3>Day template</h3>
+            <p className="muted-copy">Choose how task suggestions populate your phases.</p>
+            <div className="routine-grid">
+              {ROUTINE_OPTIONS.map((option) => (
+                <button
+                  key={option.key}
+                  className={`routine-chip ${settings.routineType === option.key ? 'active' : ''}`}
+                  onClick={() => applyRoutineTemplate(option.key)}
+                >
+                  <strong>{option.label}</strong>
+                  <small>{option.note}</small>
+                </button>
+              ))}
+            </div>
+            <h3>Phase structure and defaults</h3>
             <div className="settings-phase-list">
               {settings.phases.map((phase, index) => (
                 <div className="settings-phase-block" key={phase.id}>
@@ -913,11 +955,7 @@ export default function App() {
                   <div className="settings-phase-row">
                     <label>
                       Phase name
-                      <input
-                        type="text"
-                        value={phase.name}
-                        onChange={(event) => updatePhaseName(phase.id, event.target.value)}
-                      />
+                      <input type="text" value={phase.name} onChange={(event) => updatePhaseName(phase.id, event.target.value)} />
                     </label>
                     <label>
                       Default duration (min)
@@ -928,33 +966,12 @@ export default function App() {
                         onChange={(event) => updatePhaseDefault(phase.id, event.target.value)}
                       />
                     </label>
-                    <button
-                      className="ghost small"
-                      onClick={() => setSettingsPatch({ activePhaseId: phase.id })}
-                    >
-                      Make active
-                    </button>
+                    <button className="ghost small" onClick={() => setSettingsPatch({ activePhaseId: phase.id })}>Make active</button>
                   </div>
                 </div>
               ))}
-              <button className="secondary" onClick={() => insertPhaseAt(settings.phases.length)}>
-                + Add phase at end
-              </button>
+              <button className="secondary" onClick={() => insertPhaseAt(settings.phases.length)}>+ Add phase at end</button>
             </div>
-            <h3>Mind Check context</h3>
-            <p className="muted-copy">Timezone: {settings.preferences?.timeZone || 'UTC'}</p>
-            <p className="muted-copy">
-              Location:{' '}
-              {settings.preferences?.location
-                ? `${settings.preferences.location.latitude}, ${settings.preferences.location.longitude}`
-                : 'Not linked'}
-            </p>
-            <div className="button-row">
-              <button className="ghost" onClick={() => setSiteView('planner')}>Back to dashboard</button>
-              <button className="secondary" onClick={syncLocationNow}>Sync location</button>
-              <button className="ghost" onClick={refreshContext}>Refresh weather context</button>
-            </div>
-            {locationStatus && <p className="status-message">{locationStatus}</p>}
           </section>
         )}
 
@@ -972,23 +989,12 @@ export default function App() {
               <div className="phase-controls">
                 <label>
                   Phase duration (minutes)
-                  <input
-                    type="number"
-                    min="1"
-                    value={phaseDurationInput}
-                    onChange={(event) => setPhaseDurationInput(event.target.value)}
-                  />
+                  <input type="number" min="1" value={phaseDurationInput} onChange={(event) => setPhaseDurationInput(event.target.value)} />
                 </label>
-
                 <label>
                   Phase name
-                  <input
-                    type="text"
-                    value={activePhase.name}
-                    onChange={(event) => updateActivePhase({ name: event.target.value })}
-                  />
+                  <input type="text" value={activePhase.name} onChange={(event) => updateActivePhase({ name: event.target.value })} />
                 </label>
-
                 <div className="button-row phase-action-row">
                   <button onClick={handleStartPhase}>Start phase</button>
                   <button className="secondary" onClick={handlePausePhase}>Pause</button>
@@ -1007,7 +1013,7 @@ export default function App() {
 
               <p className="recommendation">
                 {activePhase.id === 'phase-1'
-                  ? 'Phase 1 start: anchor your morning with one high-leverage task before context switching.'
+                  ? 'Phase 1 starts your day: front-load planning, attention shaping, and one decisive action.'
                   : `You are in ${activePhase.name}. Keep transitions deliberate and visible.`}
               </p>
 
@@ -1017,22 +1023,15 @@ export default function App() {
                 <div className="context-box">
                   <p>
                     Current weather is {weather.summary} at {Math.round(weather.temperatureC)}°C.
-                    Sunrise: {formatClockFromIso(weather.sunrise, mindContext.data?.timeZone)}. Sunset:{' '}
-                    {formatClockFromIso(weather.sunset, mindContext.data?.timeZone)}.
+                    Sunrise: {formatClockFromIso(weather.sunrise, mindContext.data?.timeZone)}. Sunset: {formatClockFromIso(weather.sunset, mindContext.data?.timeZone)}.
                   </p>
                   <p>
                     UV now {weather.uvNow ?? 'n/a'}, max today {weather.uvMax ?? 'n/a'}. {weather.lightSuggestion}
                   </p>
                 </div>
               )}
-              {!weather && (
-                <p className="status-message">
-                  Location is not linked yet, so weather-aware guidance is limited to your timezone.
-                </p>
-              )}
 
               <p className="recommendation">{circadianText}</p>
-
               <div className="health-grid">
                 {HEALTH_OPTIONS.map((option) => (
                   <button
@@ -1044,9 +1043,7 @@ export default function App() {
                   </button>
                 ))}
               </div>
-
               <p className="recommendation">{recommendation}</p>
-
               <div className="button-row">
                 <button className="secondary" onClick={suggestNextAction}>Suggest next action</button>
                 <button className="ghost" onClick={refreshContext}>Refresh context</button>
@@ -1057,9 +1054,17 @@ export default function App() {
             <section className="card flow-card">
               <div className="section-header">
                 <div>
-                  <p className="card-label">Routine flow</p>
-                  <h3>Ordered checklist for this phase</h3>
+                  <p className="card-label">Task flow</p>
+                  <h3>Action list for this phase</h3>
                 </div>
+              </div>
+
+              <div className="suggestion-strip">
+                {activeSuggestions.map((suggestion) => (
+                  <button key={suggestion.title} className="ghost small" onClick={() => addSuggestionTask(suggestion)}>
+                    + {suggestion.title}
+                  </button>
+                ))}
               </div>
 
               <div className="task-list">
@@ -1072,26 +1077,24 @@ export default function App() {
                         onClick={() => toggleTask(task.id)}
                         aria-label={task.done ? `Mark ${task.title} incomplete` : `Mark ${task.title} complete`}
                       />
-
                       <div className="task-copy">
                         <strong>{task.title}</strong>
                         <span>
                           Step {index + 1}
-                          {task.minutes ? ` • ${task.minutes} min timer available` : ' • Flexible timing'}
+                          {task.minutes ? ` • ${task.minutes} min` : ' • Flexible timing'}
                         </span>
                         {taskTimerActive && (
                           <div className="nested-timer">
                             <span>Task timer: {formatSeconds(taskTimerRemaining)}</span>
-                            <button className="ghost small" onClick={stopTaskTimer}>Stop task timer</button>
+                            <button className="ghost small" onClick={stopTaskTimer}>Stop timer</button>
                           </div>
                         )}
                       </div>
-
                       <div className="task-actions">
                         <button className="ghost small" onClick={() => moveTask(task.id, 'up')}>Up</button>
                         <button className="ghost small" onClick={() => moveTask(task.id, 'down')}>Down</button>
                         {task.minutes && !taskTimerActive && (
-                          <button className="secondary small" onClick={() => startTaskTimer(task)}>Start timer</button>
+                          <button className="secondary small" onClick={() => startTaskTimer(task)}>Start</button>
                         )}
                       </div>
                     </article>
@@ -1100,19 +1103,8 @@ export default function App() {
               </div>
 
               <form className="add-task-form" onSubmit={addTask}>
-                <input
-                  type="text"
-                  placeholder="Add a task for this phase"
-                  value={taskTitleInput}
-                  onChange={(event) => setTaskTitleInput(event.target.value)}
-                />
-                <input
-                  type="number"
-                  min="1"
-                  placeholder="Timer min"
-                  value={taskMinutesInput}
-                  onChange={(event) => setTaskMinutesInput(event.target.value)}
-                />
+                <input type="text" placeholder="Add a task for this phase" value={taskTitleInput} onChange={(event) => setTaskTitleInput(event.target.value)} />
+                <input type="number" min="1" placeholder="Timer min" value={taskMinutesInput} onChange={(event) => setTaskMinutesInput(event.target.value)} />
                 <button type="submit">Add task</button>
               </form>
             </section>

--- a/src/assets/calm-banner.svg
+++ b/src/assets/calm-banner.svg
@@ -1,0 +1,30 @@
+<svg width="1600" height="520" viewBox="0 0 1600 520" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#E5F1FB"/>
+      <stop offset="1" stop-color="#F4FAF7"/>
+    </linearGradient>
+    <linearGradient id="hillBack" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#CADFD7"/>
+      <stop offset="1" stop-color="#AECAC1"/>
+    </linearGradient>
+    <linearGradient id="hillMid" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#B2CEC5"/>
+      <stop offset="1" stop-color="#89B7AA"/>
+    </linearGradient>
+    <linearGradient id="hillFront" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#9EC2B7"/>
+      <stop offset="1" stop-color="#6E9E92"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="520" fill="url(#sky)"/>
+  <circle cx="1320" cy="118" r="44" fill="#F9EFC9" opacity="0.9"/>
+  <path d="M0 314C170 286 294 290 456 324C629 361 735 372 915 338C1061 311 1181 283 1367 312C1462 328 1536 354 1600 387V520H0V314Z" fill="url(#hillBack)"/>
+  <path d="M0 366C163 338 305 338 470 368C632 398 788 404 952 368C1118 332 1298 318 1600 394V520H0V366Z" fill="url(#hillMid)"/>
+  <path d="M0 426C188 389 406 390 617 431C820 471 1029 467 1237 431C1377 406 1499 402 1600 423V520H0V426Z" fill="url(#hillFront)"/>
+  <g opacity="0.35">
+    <path d="M230 237C258 219 296 224 318 247" stroke="#8CB3A5" stroke-width="5" stroke-linecap="round"/>
+    <path d="M880 199C905 183 940 184 964 203" stroke="#8CB3A5" stroke-width="5" stroke-linecap="round"/>
+    <path d="M1125 246C1146 233 1175 234 1193 249" stroke="#8CB3A5" stroke-width="5" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,25 +1,25 @@
 :root {
   color-scheme: light;
   font-family: "Avenir Next", "Segoe UI", sans-serif;
-  line-height: 1.5;
+  line-height: 1.45;
   font-weight: 400;
-  background:
-    radial-gradient(circle at top left, rgba(255, 225, 179, 0.6), transparent 30%),
-    radial-gradient(circle at top right, rgba(159, 210, 255, 0.4), transparent 25%),
-    linear-gradient(180deg, #f6f1e8 0%, #eef4f2 100%);
-  color: #1b2a22;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  --ink: #21352b;
-  --muted: #53655b;
-  --line: rgba(33, 53, 43, 0.12);
-  --card: rgba(255, 252, 246, 0.78);
-  --card-strong: rgba(255, 248, 237, 0.95);
-  --accent: #d96b34;
-  --accent-soft: rgba(217, 107, 52, 0.14);
-  --accent-2: #2c8c72;
+  --bg-0: #eff4fa;
+  --bg-1: #e6f0ec;
+  --surface: rgba(255, 255, 255, 0.82);
+  --surface-strong: rgba(255, 255, 255, 0.93);
+  --ink: #1f3440;
+  --muted: #4f6672;
+  --line: rgba(38, 70, 86, 0.16);
+  --primary: #4f7e95;
+  --primary-strong: #3f6d83;
+  --secondary: #6b9c9f;
+  --secondary-strong: #527f82;
+  --ghost: rgba(48, 79, 96, 0.1);
+  --danger: #a13f43;
 }
 
 * {
@@ -29,6 +29,15 @@
 body {
   margin: 0;
   min-width: 320px;
+  min-height: 100vh;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 8% 8%, #ffffffc7 0, transparent 35%),
+    radial-gradient(circle at 88% 12%, #d9eef2 0, transparent 34%),
+    linear-gradient(180deg, var(--bg-0) 0%, var(--bg-1) 100%);
+}
+
+#root {
   min-height: 100vh;
 }
 
@@ -41,259 +50,172 @@ input {
   font: inherit;
 }
 
+input {
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  padding: 0.72rem 0.82rem;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.88);
+}
+
 button {
   border: 0;
   border-radius: 999px;
   cursor: pointer;
-  transition: transform 160ms ease, opacity 160ms ease, background 160ms ease;
+  background: var(--primary);
+  color: #f6fbff;
+  padding: 0.68rem 1rem;
+  transition: background 140ms ease, transform 140ms ease, opacity 140ms ease;
 }
 
 button:hover {
   transform: translateY(-1px);
+  background: var(--primary-strong);
 }
 
 button:disabled {
-  opacity: 0.65;
+  opacity: 0.6;
   cursor: wait;
   transform: none;
 }
 
-#root {
-  min-height: 100vh;
+button.secondary {
+  background: var(--secondary);
 }
 
-.app-shell {
-  min-height: 100vh;
-  display: grid;
-  grid-template-columns: 320px 1fr;
-  gap: 24px;
-  padding: 24px;
+button.secondary:hover {
+  background: var(--secondary-strong);
+}
+
+button.ghost {
+  background: var(--ghost);
+  color: var(--ink);
+}
+
+button.ghost:hover {
+  background: rgba(48, 79, 96, 0.16);
+}
+
+button.small {
+  font-size: 0.9rem;
+  padding: 0.52rem 0.78rem;
 }
 
 .auth-shell {
   min-height: 100vh;
   display: grid;
   place-items: center;
-  padding: 24px;
+  padding: 1rem;
 }
 
 .auth-card {
-  width: min(100%, 520px);
+  width: min(100%, 34rem);
   display: grid;
-  gap: 20px;
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: 32px;
-  padding: 32px;
-  box-shadow: 0 18px 50px rgba(36, 44, 38, 0.08);
+  gap: 1rem;
+}
+
+.auth-toggle {
+  display: flex;
+  gap: 0.55rem;
+}
+
+.active-tab {
+  background: var(--ink);
+}
+
+.auth-form {
+  display: grid;
+  gap: 0.72rem;
+}
+
+.auth-form label,
+.phase-controls label,
+.setup-grid label,
+.settings-phase-row label {
+  display: grid;
+  gap: 0.42rem;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.88rem;
+  padding: 0.75rem;
 }
 
 .sidebar,
-.main-grid {
-  display: grid;
-  gap: 20px;
-}
-
-.sidebar {
-  align-content: start;
-}
-
-.main-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
+.main-grid,
 .main-stack {
   display: grid;
-  gap: 20px;
+  gap: 0.88rem;
+}
+
+.main-grid,
+.main-stack {
   align-content: start;
+}
+
+.main-grid {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .card {
-  background: var(--card);
-  backdrop-filter: blur(12px);
+  border-radius: 20px;
   border: 1px solid var(--line);
-  border-radius: 28px;
-  padding: 24px;
-  box-shadow: 0 18px 50px rgba(36, 44, 38, 0.08);
+  background: var(--surface);
+  backdrop-filter: blur(8px);
+  padding: 1rem;
+  box-shadow: 0 10px 26px rgba(49, 76, 92, 0.08);
 }
 
+.topbar-card,
 .hero-card,
 .flow-card {
   grid-column: 1 / -1;
 }
 
 .topbar-card {
-  grid-column: 1 / -1;
   display: flex;
   justify-content: space-between;
-  align-items: center;
-  position: relative;
+  align-items: flex-start;
+  gap: 0.8rem;
+  position: sticky;
+  top: 0.5rem;
+  z-index: 3;
 }
 
-.eyebrow,
-.card-label {
-  margin: 0 0 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.78rem;
-  color: var(--muted);
-}
-
-.lede {
-  color: var(--muted);
-  max-width: 28ch;
-}
-
-.phase-list {
-  display: grid;
-  gap: 12px;
-}
-
-.phase-chip {
-  background: rgba(255, 255, 255, 0.56);
-  padding: 16px 18px;
-  text-align: left;
-  border: 1px solid transparent;
+.topbar-actions {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.phase-chip.active {
-  background: var(--card-strong);
-  border-color: rgba(217, 107, 52, 0.4);
-  box-shadow: inset 0 0 0 1px rgba(217, 107, 52, 0.12);
-}
-
-.phase-chip small {
-  color: var(--muted);
-}
-
-.setup-card h3 {
-  margin: 0;
-}
-
-.setup-grid {
-  display: grid;
-  gap: 12px;
-  margin: 8px 0 14px;
-}
-
-.setup-grid label {
-  display: grid;
-  gap: 8px;
-}
-
-.accent-card {
-  background: linear-gradient(135deg, rgba(255, 244, 230, 0.95), rgba(233, 247, 240, 0.88));
-}
-
-.account-card {
-  display: grid;
-  gap: 8px;
-}
-
-.muted-copy {
-  color: var(--muted);
-}
-
-.progress-track {
-  height: 12px;
-  border-radius: 999px;
-  background: rgba(27, 42, 34, 0.08);
-  overflow: hidden;
-  margin-top: 14px;
-}
-
-.progress-fill {
-  height: 100%;
-  border-radius: inherit;
-  background: linear-gradient(90deg, var(--accent), #f0b25a);
-}
-
-.hero-topline,
-.section-header,
-.task-row,
-.button-row,
-.task-actions,
-.nested-timer {
-  display: flex;
+  gap: 0.5rem;
   align-items: center;
-}
-
-.hero-topline,
-.section-header,
-.task-row {
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.timer-pill {
-  min-width: 110px;
-  text-align: center;
-  padding: 14px 18px;
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.7);
-  font-size: 1.6rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-}
-
-.timer-pill.running {
-  background: rgba(44, 140, 114, 0.14);
-  color: #175947;
-}
-
-.phase-controls {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
-  margin-top: 24px;
-}
-
-.phase-action-row {
-  align-self: end;
-}
-
-.phase-controls label,
-.add-task-form,
-.auth-form {
-  display: grid;
-  gap: 10px;
 }
 
 .profile-menu-wrap {
   position: relative;
 }
 
-.topbar-actions {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
 .profile-trigger {
-  width: 46px;
-  height: 46px;
-  border-radius: 999px;
+  width: 2.6rem;
+  height: 2.6rem;
   padding: 0;
+  border-radius: 999px;
   font-weight: 700;
-  background: linear-gradient(135deg, #2c8c72, #1f6b57);
+  background: linear-gradient(130deg, #648ea4, #496f83);
 }
 
 .profile-menu {
   position: absolute;
   right: 0;
-  top: calc(100% + 10px);
-  min-width: 190px;
-  padding: 8px;
-  border-radius: 16px;
+  top: calc(100% + 0.45rem);
+  min-width: 10.8rem;
   border: 1px solid var(--line);
-  background: rgba(255, 252, 246, 0.98);
-  box-shadow: 0 14px 30px rgba(36, 44, 38, 0.14);
+  border-radius: 14px;
+  background: var(--surface-strong);
+  box-shadow: 0 14px 30px rgba(33, 58, 72, 0.18);
   display: grid;
-  gap: 6px;
-  z-index: 5;
+  gap: 0.3rem;
+  padding: 0.34rem;
 }
 
 .menu-item {
@@ -301,192 +223,305 @@ button:disabled {
   text-align: left;
 }
 
-input {
+.calm-banner {
   width: 100%;
+  height: auto;
+  display: block;
   border-radius: 18px;
   border: 1px solid var(--line);
-  padding: 14px 16px;
-  background: rgba(255, 255, 255, 0.8);
-  color: var(--ink);
 }
 
-.button-row,
-.task-actions,
-.nested-timer,
-.health-grid {
-  gap: 10px;
-  flex-wrap: wrap;
+.eyebrow,
+.card-label {
+  margin: 0 0 0.24rem;
+  text-transform: uppercase;
+  letter-spacing: 0.11em;
+  font-size: 0.72rem;
+  color: var(--muted);
 }
 
-button {
-  background: var(--accent);
-  color: #fffaf5;
-  padding: 12px 18px;
-}
-
-button.secondary {
-  background: var(--accent-2);
-}
-
-button.ghost {
-  background: rgba(33, 53, 43, 0.08);
-  color: var(--ink);
-}
-
-button.small {
-  padding: 9px 14px;
-  font-size: 0.92rem;
-}
-
-.health-option {
-  background: rgba(255, 255, 255, 0.7);
-  color: var(--ink);
-}
-
-.health-option.selected {
-  background: var(--accent-soft);
-  color: #783411;
-}
-
-.auth-toggle {
-  display: flex;
-  gap: 10px;
-}
-
-.active-tab {
-  background: var(--ink);
-  color: #fffaf5;
-}
-
-.status-message {
+h1,
+h2,
+h3,
+p {
   margin: 0;
+}
+
+h1 {
+  font-size: clamp(1.35rem, 4vw, 1.9rem);
+}
+
+h2 {
+  font-size: clamp(1.2rem, 3.4vw, 1.65rem);
+}
+
+h3 {
+  font-size: clamp(1.05rem, 3vw, 1.24rem);
+}
+
+.lede,
+.muted-copy,
+.status-message,
+.recommendation {
   color: var(--muted);
 }
 
 .status-message.error {
-  color: #9d2f1d;
+  color: var(--danger);
 }
 
-.recommendation {
-  margin-bottom: 0;
+.phase-list {
+  display: grid;
+  gap: 0.56rem;
+}
+
+.phase-chip {
+  text-align: left;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid transparent;
+  padding: 0.78rem 0.9rem;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.phase-chip small {
   color: var(--muted);
-  max-width: 56ch;
+}
+
+.phase-chip.active {
+  border-color: rgba(70, 108, 127, 0.45);
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.setup-grid {
+  display: grid;
+  gap: 0.58rem;
+  margin: 0.7rem 0 0.9rem;
+}
+
+.progress-track {
+  height: 0.56rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(56, 92, 110, 0.18);
+  margin-top: 0.7rem;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #7ea6ba, #98b9a8);
+}
+
+.hero-topline,
+.section-header,
+.task-row,
+.button-row,
+.task-actions,
+.nested-timer,
+.health-grid {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.hero-topline,
+.section-header,
+.task-row {
+  justify-content: space-between;
+}
+
+.timer-pill {
+  min-width: 5.95rem;
+  text-align: center;
+  border-radius: 14px;
+  padding: 0.56rem 0.75rem;
+  background: rgba(255, 255, 255, 0.82);
+  font-size: 1.32rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.timer-pill.running {
+  background: rgba(107, 156, 159, 0.24);
+  color: #295b62;
+}
+
+.phase-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.72rem;
+  margin-top: 0.9rem;
+}
+
+.phase-action-row {
+  align-self: end;
 }
 
 .context-box {
-  margin: 12px 0;
-  padding: 14px 16px;
-  border-radius: 16px;
-  border: 1px solid rgba(33, 53, 43, 0.1);
-  background: rgba(255, 255, 255, 0.65);
+  margin: 0.72rem 0;
+  padding: 0.72rem;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.72);
 }
 
-.context-box p {
-  margin: 0 0 6px;
+.context-box p + p {
+  margin-top: 0.32rem;
+}
+
+.health-option {
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink);
+}
+
+.health-option.selected {
+  background: rgba(79, 126, 149, 0.2);
+  color: #23485b;
+}
+
+.routine-grid,
+.settings-phase-list {
+  display: grid;
+  gap: 0.62rem;
+  margin-top: 0.7rem;
+}
+
+.routine-chip {
+  text-align: left;
+  display: grid;
+  gap: 0.2rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink);
+}
+
+.routine-chip.active {
+  background: rgba(79, 126, 149, 0.22);
+}
+
+.routine-chip small {
   color: var(--muted);
 }
 
-.context-box p:last-child {
-  margin-bottom: 0;
-}
-
-.nav-note-card {
-  padding: 18px;
-}
-
-.settings-phase-list {
-  display: grid;
-  gap: 14px;
-  margin-bottom: 20px;
-}
-
 .settings-phase-block {
-  border: 1px solid rgba(33, 53, 43, 0.1);
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.62);
-  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 0.65rem;
   display: grid;
-  gap: 10px;
+  gap: 0.58rem;
 }
 
 .settings-phase-row {
   display: grid;
-  gap: 10px;
-  grid-template-columns: 1.5fr 1fr auto;
-  align-items: end;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.58rem;
 }
 
 .insert-btn {
   justify-self: start;
 }
 
+.suggestion-strip {
+  display: flex;
+  gap: 0.45rem;
+  overflow-x: auto;
+  padding-bottom: 0.2rem;
+}
+
+.suggestion-strip button {
+  white-space: nowrap;
+}
+
 .task-list {
   display: grid;
-  gap: 14px;
-  margin-top: 18px;
+  gap: 0.62rem;
+  margin-top: 0.7rem;
 }
 
 .task-row {
-  padding: 16px 18px;
-  border-radius: 22px;
-  background: rgba(255, 255, 255, 0.64);
-  border: 1px solid rgba(33, 53, 43, 0.08);
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.75);
+  padding: 0.72rem;
   align-items: flex-start;
 }
 
 .task-row.done {
-  opacity: 0.62;
+  opacity: 0.64;
+}
+
+.task-check {
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-top: 0.22rem;
+  border-radius: 999px;
+  padding: 0;
+  background: rgba(47, 79, 95, 0.2);
+}
+
+.task-check.checked {
+  background: var(--secondary);
 }
 
 .task-copy {
   flex: 1;
+  min-width: 0;
 }
 
 .task-copy span {
   display: block;
   color: var(--muted);
-}
-
-.task-check {
-  width: 22px;
-  height: 22px;
-  margin-top: 4px;
-  border-radius: 999px;
-  padding: 0;
-  background: rgba(33, 53, 43, 0.12);
-}
-
-.task-check.checked {
-  background: var(--accent-2);
+  margin-top: 0.12rem;
 }
 
 .nested-timer {
-  margin-top: 10px;
+  margin-top: 0.48rem;
 }
 
 .add-task-form {
-  grid-template-columns: 1fr 140px auto;
-  margin-top: 20px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.5rem;
+  margin-top: 0.85rem;
 }
 
-@media (max-width: 960px) {
-  .app-shell,
-  .main-grid,
-  .phase-controls,
+@media (min-width: 700px) {
+  .app-shell {
+    padding: 1rem;
+  }
+
+  .phase-controls {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .add-task-form {
-    grid-template-columns: 1fr;
-  }
-
-  .sidebar {
-    order: 2;
-  }
-
-  .topbar-card {
-    align-items: flex-start;
-    gap: 12px;
+    grid-template-columns: 1fr 8.8rem auto;
   }
 
   .settings-phase-row {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1.45fr 1fr auto;
+    align-items: end;
+  }
+}
+
+@media (min-width: 1080px) {
+  .app-shell {
+    grid-template-columns: minmax(17.5rem, 21rem) minmax(0, 1fr);
+    gap: 1rem;
+    padding: 1rem 1rem 1.2rem;
+  }
+
+  .sidebar {
+    align-content: start;
+    position: sticky;
+    top: 0.8rem;
+    height: fit-content;
+  }
+
+  .main-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- add richer phase task suggestions and routine templates (Session vs Integration)
- stop showing default minute values in left nav chips; show open task counts instead
- add first-login setup wording to keep defaults out of persistent nav context
- add calming banner artwork and new soothing blue/teal visual system
- rework layout and controls for mobile-first readability and navigation
- align backend default phase/task data with frontend defaults

## Validation
- npm run build
