### PR TITLE
Audit and harden Focus Flow baseline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 node_modules
 dist
 .DS_Store
+data
+server/*.db
+server/*.db-*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 .DS_Store
 data
+server/*.db
+server/*.db-*

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,76 @@
+# Focus Flow Memory
+
+## Purpose
+
+Focus Flow is a local-first ADHD-friendly planning app. The product goal is not generic task management; it is helping a user move through a day with less friction by combining:
+
+- named phases across the day
+- ordered, low-friction task lists inside each phase
+- nested task timers inside phase timers
+- a daily check-in that adapts tone and task pressure
+- lightweight weather/circadian context
+
+The current tone should stay calm, practical, and non-shaming. Guidance should feel grounded and human, not clinical or robotic.
+
+## Current Product Shape
+
+- Local web app for testing on a developer machine and local network.
+- User accounts exist and settings persist per user in SQLite.
+- Core planner model:
+  - `phases[]`
+  - each phase has `tasks[]`
+  - task `type` is `template` or `oneoff`
+  - unfinished one-off tasks can carry over day to day
+  - day mode can shift between `session` and `integration`
+- Check-in flow captures wake time, rough day quality, and attention state.
+- Mind/context layer blends:
+  - time of day
+  - local weather and UV
+  - sunrise/sunset
+  - optional cycle tracking
+  - ADHD-oriented circadian framing
+
+## Theme And UX Intent
+
+- Visual direction: calm, airy, blue/teal, readable, mobile-first.
+- Product should feel supportive and focused, not busy or gamified.
+- The app is meant to reduce activation energy. Default interactions should stay obvious and forgiving.
+- Avoid cluttering the nav with too much persistent metadata. The planner itself should carry the operational detail.
+
+## Architecture
+
+- Frontend: React + Vite in [src/App.jsx](/Users/jasonkennedy/Projects/task-manager/src/App.jsx)
+- Styling: single stylesheet in [src/styles.css](/Users/jasonkennedy/Projects/task-manager/src/styles.css)
+- Backend: Express API in [server/server.js](/Users/jasonkennedy/Projects/task-manager/server/server.js)
+- Persistence: SQLite via `better-sqlite3` in [server/db.js](/Users/jasonkennedy/Projects/task-manager/server/db.js)
+- Default user state normalization lives in [server/defaultState.js](/Users/jasonkennedy/Projects/task-manager/server/defaultState.js)
+
+## Runtime Model
+
+- Dev client runs on port `3000`
+- API runs on port `3001`
+- Docker compose currently runs the development stack, not a production-built image
+- SQLite database path is `data/focus-flow.db`
+
+## Release Context
+
+- Repo: `jkomg/task-manager`
+- Public GitHub repo
+- PR-based workflow is expected for changes
+- Current branch at handoff time: `codex/audit-hardening-focusflow`
+- Recent release lineage includes tag `v1.0.0`
+
+## Engineering Notes
+
+- Normalize persisted state on every read/write boundary
+- Be careful with anything day-based: use the user's local timezone, not UTC midnight
+- Local browser-only state should be scoped per user where it affects behavior
+- SQLite/runtime artifacts should never be committed
+- Security posture is still lightweight because this is a local-first prototype, but obvious gaps should still be closed
+
+## Known Next Areas
+
+- move Docker from dev-mode runtime to a more production-like container path
+- add tests around auth/session expiry and daily reset logic
+- reduce the size and complexity of `src/App.jsx` by extracting focused components/hooks
+- decide how much of the circadian/cycle guidance should remain in-app versus linked or collapsible

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker compose up --build
 
 App URL: [http://localhost:3000](http://localhost:3000)
 
-LAN test URL: [http://192.168.1.115:3000](http://192.168.1.115:3000)
+LAN test URL: `http://<your-local-ip>:3000`
 
 API URL: `http://localhost:3001`
 
@@ -37,6 +37,7 @@ npm run dev
 
 - SQLite database path: `data/focus-flow.db`
 - Session state uses an HTTP-only cookie in the browser.
+- Local runtime artifacts should stay out of git and out of Docker build context.
 
 ## Change Management
 

--- a/server/db.js
+++ b/server/db.js
@@ -4,11 +4,13 @@ import Database from 'better-sqlite3';
 
 const dataDir = path.resolve('data');
 const dbPath = path.join(dataDir, 'focus-flow.db');
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 30;
 
 fs.mkdirSync(dataDir, { recursive: true });
 
 const db = new Database(dbPath);
 db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
 
 db.exec(`
   CREATE TABLE IF NOT EXISTS users (
@@ -24,8 +26,22 @@ db.exec(`
     token TEXT PRIMARY KEY,
     user_id TEXT NOT NULL,
     created_at TEXT NOT NULL,
+    expires_at TEXT,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
   );
+`);
+
+const sessionColumns = db.prepare('PRAGMA table_info(sessions)').all();
+
+if (!sessionColumns.some((column) => column.name === 'expires_at')) {
+  db.exec('ALTER TABLE sessions ADD COLUMN expires_at TEXT');
+  db.prepare('UPDATE sessions SET expires_at = ? WHERE expires_at IS NULL')
+    .run(new Date(Date.now() + SESSION_TTL_MS).toISOString());
+}
+
+db.exec(`
+  CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
+  CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);
 `);
 
 export default db;

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,7 @@ import { buildDefaultState, normalizeState } from './defaultState.js';
 const app = express();
 const PORT = 3001;
 const SESSION_COOKIE = 'focus_flow_session';
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 30;
 const WEATHER_CODE_LABELS = {
   0: 'clear',
   1: 'mostly clear',
@@ -38,7 +39,14 @@ const WEATHER_CODE_LABELS = {
   99: 'thunderstorms with hail',
 };
 
+app.disable('x-powered-by');
 app.use(express.json({ limit: '1mb' }));
+app.use((_req, res, next) => {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('Referrer-Policy', 'same-origin');
+  next();
+});
 
 function parseCookies(cookieHeader = '') {
   return Object.fromEntries(
@@ -50,7 +58,11 @@ function parseCookies(cookieHeader = '') {
         const separatorIndex = part.indexOf('=');
         const key = separatorIndex >= 0 ? part.slice(0, separatorIndex) : part;
         const value = separatorIndex >= 0 ? part.slice(separatorIndex + 1) : '';
-        return [key, decodeURIComponent(value)];
+        try {
+          return [key, decodeURIComponent(value)];
+        } catch {
+          return [key, value];
+        }
       })
   );
 }
@@ -58,7 +70,7 @@ function parseCookies(cookieHeader = '') {
 function setSessionCookie(res, token) {
   res.setHeader(
     'Set-Cookie',
-    `${SESSION_COOKIE}=${encodeURIComponent(token)}; HttpOnly; Path=/; SameSite=Lax; Max-Age=${60 * 60 * 24 * 30}`
+    `${SESSION_COOKIE}=${encodeURIComponent(token)}; HttpOnly; Path=/; SameSite=Lax; Max-Age=${60 * 60 * 24 * 30}; Priority=High`
   );
 }
 
@@ -74,6 +86,26 @@ function publicUser(row) {
   };
 }
 
+function parseStoredSettings(settingsJson) {
+  try {
+    return normalizeState(JSON.parse(settingsJson));
+  } catch {
+    return buildDefaultState();
+  }
+}
+
+function purgeExpiredSessions(nowIso = new Date().toISOString()) {
+  db.prepare('DELETE FROM sessions WHERE expires_at IS NOT NULL AND expires_at <= ?').run(nowIso);
+}
+
+function createSession(userId) {
+  const createdAt = new Date();
+  const token = crypto.randomUUID();
+  db.prepare('INSERT INTO sessions (token, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)')
+    .run(token, userId, createdAt.toISOString(), new Date(createdAt.getTime() + SESSION_TTL_MS).toISOString());
+  return token;
+}
+
 function requireAuth(req, res, next) {
   const cookies = parseCookies(req.headers.cookie);
   const token = cookies[SESSION_COOKIE];
@@ -82,14 +114,17 @@ function requireAuth(req, res, next) {
     return res.status(401).json({ error: 'Authentication required.' });
   }
 
+  purgeExpiredSessions();
+  const nowIso = new Date().toISOString();
   const row = db
     .prepare(
       `SELECT users.id, users.email, users.display_name, users.settings_json
        FROM sessions
        JOIN users ON users.id = sessions.user_id
-       WHERE sessions.token = ?`
+       WHERE sessions.token = ?
+         AND (sessions.expires_at IS NULL OR sessions.expires_at > ?)`
     )
-    .get(token);
+    .get(token, nowIso);
 
   if (!row) {
     clearSessionCookie(res);
@@ -165,9 +200,7 @@ app.post('/api/auth/register', (req, res) => {
      VALUES (?, ?, ?, ?, ?, ?)`
   ).run(id, email, passwordHash, displayName, settings, new Date().toISOString());
 
-  const token = crypto.randomUUID();
-  db.prepare('INSERT INTO sessions (token, user_id, created_at) VALUES (?, ?, ?)')
-    .run(token, id, new Date().toISOString());
+  const token = createSession(id);
 
   setSessionCookie(res, token);
 
@@ -193,15 +226,13 @@ app.post('/api/auth/login', (req, res) => {
     return res.status(401).json({ error: 'Invalid email or password.' });
   }
 
-  const token = crypto.randomUUID();
-  db.prepare('INSERT INTO sessions (token, user_id, created_at) VALUES (?, ?, ?)')
-    .run(token, user.id, new Date().toISOString());
+  const token = createSession(user.id);
 
   setSessionCookie(res, token);
 
   return res.json({
     user: publicUser(user),
-    settings: normalizeState(JSON.parse(user.settings_json)),
+    settings: parseStoredSettings(user.settings_json),
   });
 });
 
@@ -214,7 +245,7 @@ app.post('/api/auth/logout', requireAuth, (req, res) => {
 app.get('/api/auth/session', requireAuth, (req, res) => {
   res.json({
     user: publicUser(req.user),
-    settings: normalizeState(JSON.parse(req.user.settings_json)),
+    settings: parseStoredSettings(req.user.settings_json),
   });
 });
 
@@ -230,7 +261,7 @@ app.put('/api/settings', requireAuth, (req, res) => {
 app.get('/api/context/brief', requireAuth, async (req, res) => {
   const latitude = Number(req.query.lat);
   const longitude = Number(req.query.lon);
-  const persisted = normalizeState(JSON.parse(req.user.settings_json));
+  const persisted = parseStoredSettings(req.user.settings_json);
   const timeZone = String(req.query.timeZone ?? req.query.tz ?? persisted.preferences?.timeZone ?? 'UTC');
   const timeDetails = getTimeDetails(timeZone);
 
@@ -287,6 +318,14 @@ app.get('/api/context/brief', requireAuth, async (req, res) => {
       weather: null,
     });
   }
+});
+
+app.use((error, _req, res, _next) => {
+  console.error(error);
+  if (res.headersSent) {
+    return;
+  }
+  res.status(500).json({ error: 'Internal server error.' });
 });
 
 app.listen(PORT, () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -299,6 +299,31 @@ function formatClockFromIso(iso, timeZone) {
   }
 }
 
+function getBrowserTimeZone() {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+}
+
+function getDateKey(timeZone = getBrowserTimeZone()) {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(new Date());
+    const year = parts.find((part) => part.type === 'year')?.value ?? '1970';
+    const month = parts.find((part) => part.type === 'month')?.value ?? '01';
+    const day = parts.find((part) => part.type === 'day')?.value ?? '01';
+    return `${year}-${month}-${day}`;
+  } catch {
+    return new Date().toISOString().slice(0, 10);
+  }
+}
+
+function storageKeyForUser(userId, name) {
+  return `focusflow:${userId ?? 'guest'}:${name}`;
+}
+
 function circadianWindow(hour) {
   if (hour >= 5 && hour < 8) return {
     label: 'Cortisol Awakening Response',
@@ -831,10 +856,9 @@ export default function App() {
   const [phaseRemaining, setPhaseRemaining] = useState(DEFAULT_SETTINGS.phases[0].defaultMinutes * 60);
   const [phaseRunning, setPhaseRunning] = useState(false);
   const [taskTimers, setTaskTimers] = useState({});
-  const todayKey = new Date().toISOString().slice(0, 10);
-  const [checkInDone, setCheckInDone] = useState(
-    () => localStorage.getItem('checkInDone') === todayKey
-  );
+  const browserTimeZone = getBrowserTimeZone();
+  const todayKey = getDateKey(settings.preferences?.timeZone || browserTimeZone);
+  const [checkInDone, setCheckInDone] = useState(false);
   const [collapsedPhases, setCollapsedPhases] = useState(
     () => new Set(DEFAULT_SETTINGS.phases.map((p) => p.id).filter((id) => id !== DEFAULT_SETTINGS.activePhaseId))
   );
@@ -848,13 +872,9 @@ export default function App() {
   const [locationStatus, setLocationStatus] = useState('');
   const [mindContext, setMindContext] = useState({ loading: false, data: null, error: '' });
   const [mindAction, setMindAction] = useState('');
-  const [dayCheck, setDayCheck] = useState(
-    () => localStorage.getItem('dayCheck_' + new Date().toISOString().slice(0, 10)) ?? null
-  );
+  const [dayCheck, setDayCheck] = useState(null);
   const [onboardingStep, setOnboardingStep] = useState(0);
-  const [wakeHour, setWakeHour] = useState(
-    () => { const v = localStorage.getItem('wakeHour_' + new Date().toISOString().slice(0, 10)); return v !== null ? Number(v) : null; }
-  );
+  const [wakeHour, setWakeHour] = useState(null);
   const [profileExpanded, setProfileExpanded] = useState(false);
   const [authForm, setAuthForm] = useState({
     displayName: '',
@@ -926,6 +946,27 @@ export default function App() {
   }, []);
 
   useEffect(() => {
+    if (!user) {
+      setCheckInDone(false);
+      setDayCheck(null);
+      setWakeHour(null);
+      setRoutineOverridden(false);
+      return;
+    }
+
+    const checkInKey = storageKeyForUser(user.id, `checkInDone:${todayKey}`);
+    const dayCheckKey = storageKeyForUser(user.id, `dayCheck:${todayKey}`);
+    const wakeHourKey = storageKeyForUser(user.id, `wakeHour:${todayKey}`);
+    const storedWakeHour = window.localStorage.getItem(wakeHourKey);
+    const parsedWakeHour = storedWakeHour === null ? null : Number(storedWakeHour);
+
+    setCheckInDone(window.localStorage.getItem(checkInKey) === 'true');
+    setDayCheck(window.localStorage.getItem(dayCheckKey) ?? null);
+    setWakeHour(Number.isFinite(parsedWakeHour) ? parsedWakeHour : null);
+    setRoutineOverridden(false);
+  }, [todayKey, user]);
+
+  useEffect(() => {
     if (!activePhase) {
       return;
     }
@@ -994,7 +1035,6 @@ export default function App() {
     if (!user) {
       return;
     }
-    const browserTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
     if (settings.preferences?.timeZone !== browserTimeZone) {
       setSettings((current) => ({
         ...current,
@@ -1177,7 +1217,10 @@ export default function App() {
   }
 
   function addSuggestionTask(phaseId, suggestion) {
-    updateTasksInPhase(phaseId, (tasks) => [...tasks, createTask(suggestion.title, null, 'oneoff')]);
+    updateTasksInPhase(phaseId, (tasks) => [
+      ...tasks,
+      createTask(suggestion.title, suggestion.minutes ?? null, 'oneoff'),
+    ]);
   }
 
   function addTemplateTaskToPhase(phaseId, title) {
@@ -1359,18 +1402,18 @@ export default function App() {
 
   function handleCompleteCheckin() {
     triggerDailyReset();
-    localStorage.setItem('checkInDone', todayKey);
+    window.localStorage.setItem(storageKeyForUser(user?.id, `checkInDone:${todayKey}`), 'true');
     setCheckInDone(true);
   }
 
   function handleSkipCheckin() {
     triggerDailyReset();
-    localStorage.setItem('checkInDone', todayKey);
+    window.localStorage.setItem(storageKeyForUser(user?.id, `checkInDone:${todayKey}`), 'true');
     setCheckInDone(true);
   }
 
   function handleDayCheck(result) {
-    localStorage.setItem('dayCheck_' + todayKey, result);
+    window.localStorage.setItem(storageKeyForUser(user?.id, `dayCheck:${todayKey}`), result);
     setDayCheck(result);
     setRoutineOverridden(false);
     const nextType = result === 'clearly-worse' ? 'integration' : 'session';
@@ -1893,7 +1936,10 @@ export default function App() {
                     <button
                       key={label}
                       className={`day-check-btn ${wakeHour === value ? 'selected' : ''}`}
-                      onClick={() => { localStorage.setItem('wakeHour_' + todayKey, String(value)); setWakeHour(value); }}
+                      onClick={() => {
+                        window.localStorage.setItem(storageKeyForUser(user?.id, `wakeHour:${todayKey}`), String(value));
+                        setWakeHour(value);
+                      }}
                     >
                       {label}
                     </button>


### PR DESCRIPTION
## Summary
- add an in-repo Focus Flow memory document to capture product intent, architecture, and UX direction
- harden auth/session handling with server-side session expiry, cleanup, and safer JSON/state parsing
- scope daily check-in local state by user and local timezone-aware day key
- preserve suggestion task timer minutes so quick-added tasks behave as expected
- ignore local SQLite/runtime artifacts in git and Docker build context
- refresh README notes to match current local/LAN behavior

## Validation
- npm run build
- node --check server/server.js
- node --check server/db.js

## Audit notes
- npm audit --omit=dev could not complete in the sandbox because DNS access to registry.npmjs.org was unavailable.
