### PR TITLE
Add auth seam and session/admin hooks

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -39,11 +39,14 @@ The current tone should stay calm, practical, and non-shaming. Guidance should f
 
 ## Architecture
 
-- Frontend: React + Vite in [src/App.jsx](/Users/jasonkennedy/Projects/task-manager/src/App.jsx)
+- Frontend: React + Vite with an app coordinator in [src/App.jsx](/Users/jasonkennedy/Projects/task-manager/src/App.jsx)
+- Planner/onboarding/admin/profile/settings are now split into focused views/components under [src/views](/Users/jasonkennedy/Projects/task-manager/src/views) and [src/components](/Users/jasonkennedy/Projects/task-manager/src/components)
+- Frontend session/admin state now lives in hooks under [src/hooks](/Users/jasonkennedy/Projects/task-manager/src/hooks)
 - Styling: single stylesheet in [src/styles.css](/Users/jasonkennedy/Projects/task-manager/src/styles.css)
 - Backend: Express API in [server/server.js](/Users/jasonkennedy/Projects/task-manager/server/server.js)
 - Persistence: SQLite via `better-sqlite3` in [server/db.js](/Users/jasonkennedy/Projects/task-manager/server/db.js)
 - Default user state normalization lives in [server/defaultState.js](/Users/jasonkennedy/Projects/task-manager/server/defaultState.js)
+- Auth/provider seam lives in [server/auth.js](/Users/jasonkennedy/Projects/task-manager/server/auth.js)
 
 ## Runtime Model
 
@@ -69,10 +72,11 @@ The current tone should stay calm, practical, and non-shaming. Guidance should f
 - Security posture is still lightweight because this is a local-first prototype, but obvious gaps should still be closed
 - Local admin/operator controls now live in-app and are meant to evolve into a hosted admin plane later
 - Near-term hosted direction assumes managed auth, but local development can keep first-party auth as a stand-in
+- User identity now has explicit provider/status fields so hosted auth can migrate without another schema rewrite
 
 ## Known Next Areas
 
 - move Docker from dev-mode runtime to a more production-like container path
-- add tests around auth/session expiry and daily reset logic
-- reduce the size and complexity of `src/App.jsx` by extracting focused components/hooks
+- add tests around auth/session expiry, auth-mode switching, and daily reset logic
+- keep shrinking `src/App.jsx` by pulling out planner state/timer logic next
 - decide how much of the circadian/cycle guidance should remain in-app versus linked or collapsible

--- a/README.md
+++ b/README.md
@@ -48,7 +48,14 @@ npm run dev
 
 - SQLite database path: `data/focus-flow.db`
 - Session state uses an HTTP-only cookie in the browser.
+- User records now track `auth_provider`, `auth_subject`, `account_status`, and `last_login_at` so local password auth can be swapped for managed auth later without rewriting the user model.
 - Local runtime artifacts should stay out of git and out of Docker build context.
+
+## Auth Mode
+
+- `AUTH_MODE=local` is the default for local development.
+- `AUTH_MODE=managed` disables password sign-in and registration in the UI/API so the app can be wired to a managed identity provider later.
+- `MANAGED_AUTH_PROVIDER` is an optional label shown in the UI/admin panel when managed mode is enabled.
 
 ## Change Management
 

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,0 +1,49 @@
+import bcrypt from 'bcryptjs';
+
+const AUTH_MODE = process.env.AUTH_MODE === 'managed' ? 'managed' : 'local';
+const MANAGED_AUTH_PROVIDER = String(process.env.MANAGED_AUTH_PROVIDER ?? '').trim() || null;
+
+export function getAuthConfig() {
+  return {
+    mode: AUTH_MODE,
+    passwordSignInEnabled: AUTH_MODE === 'local',
+    registrationEnabled: AUTH_MODE === 'local',
+    managedProvider: AUTH_MODE === 'managed' ? MANAGED_AUTH_PROVIDER ?? 'external' : null,
+  };
+}
+
+export function normalizeEmail(email) {
+  return String(email ?? '').trim().toLowerCase();
+}
+
+export function assertPasswordAuthEnabled() {
+  if (AUTH_MODE === 'local') {
+    return;
+  }
+  const error = new Error('Password sign-in is disabled for this deployment.');
+  error.statusCode = 503;
+  throw error;
+}
+
+export function buildLocalIdentity(email) {
+  const normalizedEmail = normalizeEmail(email);
+  return {
+    authProvider: 'local',
+    authSubject: normalizedEmail,
+  };
+}
+
+export function hashPassword(password) {
+  return bcrypt.hashSync(String(password ?? ''), 10);
+}
+
+export function verifyPassword(password, passwordHash) {
+  if (!passwordHash) {
+    return false;
+  }
+  return bcrypt.compareSync(String(password ?? ''), passwordHash);
+}
+
+export function canUsePasswordAuth(user) {
+  return user?.auth_provider === 'local' && typeof user?.password_hash === 'string' && user.password_hash.length > 0;
+}

--- a/server/db.js
+++ b/server/db.js
@@ -13,41 +13,45 @@ const DEFAULT_FEATURE_FLAGS = [
   { key: 'proactive_suggestions', enabled: 1, description: 'Show proactive task recommendations after check-in.' },
 ];
 
-fs.mkdirSync(dataDir, { recursive: true });
-
-const db = new Database(dbPath);
-db.pragma('journal_mode = WAL');
-db.pragma('foreign_keys = ON');
-
-db.exec(`
-  CREATE TABLE IF NOT EXISTS users (
+const USERS_TABLE_BODY = `
+  (
     id TEXT PRIMARY KEY,
     email TEXT NOT NULL UNIQUE,
-    password_hash TEXT NOT NULL,
+    password_hash TEXT,
     display_name TEXT NOT NULL,
     role TEXT NOT NULL DEFAULT 'user',
+    auth_provider TEXT NOT NULL DEFAULT 'local',
+    auth_subject TEXT NOT NULL,
+    account_status TEXT NOT NULL DEFAULT 'active',
     settings_json TEXT NOT NULL,
-    created_at TEXT NOT NULL
-  );
+    created_at TEXT NOT NULL,
+    last_login_at TEXT
+  )
+`;
 
-  CREATE TABLE IF NOT EXISTS sessions (
+const SESSIONS_TABLE_BODY = `
+  (
     token TEXT PRIMARY KEY,
     user_id TEXT NOT NULL,
     created_at TEXT NOT NULL,
     expires_at TEXT,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-  );
+  )
+`;
 
-  CREATE TABLE IF NOT EXISTS feature_flags (
+const FEATURE_FLAGS_TABLE_BODY = `
+  (
     key TEXT PRIMARY KEY,
     enabled INTEGER NOT NULL DEFAULT 1,
     description TEXT NOT NULL DEFAULT '',
     updated_at TEXT NOT NULL,
     updated_by_user_id TEXT,
     FOREIGN KEY (updated_by_user_id) REFERENCES users(id) ON DELETE SET NULL
-  );
+  )
+`;
 
-  CREATE TABLE IF NOT EXISTS audit_events (
+const AUDIT_EVENTS_TABLE_BODY = `
+  (
     id TEXT PRIMARY KEY,
     event_type TEXT NOT NULL,
     level TEXT NOT NULL DEFAULT 'info',
@@ -59,15 +63,154 @@ db.exec(`
     created_at TEXT NOT NULL,
     FOREIGN KEY (actor_user_id) REFERENCES users(id) ON DELETE SET NULL,
     FOREIGN KEY (target_user_id) REFERENCES users(id) ON DELETE SET NULL
-  );
+  )
+`;
+
+fs.mkdirSync(dataDir, { recursive: true });
+
+const db = new Database(dbPath);
+db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS users ${USERS_TABLE_BODY};
+
+  CREATE TABLE IF NOT EXISTS sessions ${SESSIONS_TABLE_BODY};
+
+  CREATE TABLE IF NOT EXISTS feature_flags ${FEATURE_FLAGS_TABLE_BODY};
+
+  CREATE TABLE IF NOT EXISTS audit_events ${AUDIT_EVENTS_TABLE_BODY};
 `);
 
-const userColumns = db.prepare('PRAGMA table_info(users)').all();
-const sessionColumns = db.prepare('PRAGMA table_info(sessions)').all();
+function rebuildUsersTableIfNeeded() {
+  const userColumns = db.prepare('PRAGMA table_info(users)').all();
+  const columnNames = new Set(userColumns.map((column) => column.name));
+  const passwordHashColumn = userColumns.find((column) => column.name === 'password_hash');
+  const needsRebuild =
+    !columnNames.has('auth_provider') ||
+    !columnNames.has('auth_subject') ||
+    !columnNames.has('account_status') ||
+    !columnNames.has('last_login_at') ||
+    passwordHashColumn?.notnull === 1;
 
-if (!userColumns.some((column) => column.name === 'role')) {
-  db.exec("ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user'");
+  if (!needsRebuild) {
+    return;
+  }
+
+  const roleExpression = columnNames.has('role') ? "COALESCE(role, 'user')" : "'user'";
+  const authProviderExpression = columnNames.has('auth_provider') ? "COALESCE(auth_provider, 'local')" : "'local'";
+  const authSubjectExpression = columnNames.has('auth_subject')
+    ? "COALESCE(auth_subject, email, id)"
+    : "COALESCE(email, id)";
+  const accountStatusExpression = columnNames.has('account_status')
+    ? "COALESCE(account_status, 'active')"
+    : "'active'";
+  const lastLoginExpression = columnNames.has('last_login_at') ? 'last_login_at' : 'NULL';
+  const passwordHashExpression = columnNames.has('password_hash') ? 'password_hash' : 'NULL';
+
+  const migrateUsers = db.transaction(() => {
+    db.pragma('foreign_keys = OFF');
+    db.exec('ALTER TABLE users RENAME TO users_legacy');
+    db.exec(`CREATE TABLE users ${USERS_TABLE_BODY}`);
+    db.exec(`
+      INSERT INTO users (
+        id,
+        email,
+        password_hash,
+        display_name,
+        role,
+        auth_provider,
+        auth_subject,
+        account_status,
+        settings_json,
+        created_at,
+        last_login_at
+      )
+      SELECT
+        id,
+        email,
+        ${passwordHashExpression},
+        display_name,
+        ${roleExpression},
+        ${authProviderExpression},
+        ${authSubjectExpression},
+        ${accountStatusExpression},
+        settings_json,
+        created_at,
+        ${lastLoginExpression}
+      FROM users_legacy
+    `);
+    db.exec('DROP TABLE users_legacy');
+    db.pragma('foreign_keys = ON');
+  });
+
+  migrateUsers();
 }
+
+rebuildUsersTableIfNeeded();
+
+function tableReferencesLegacyUsers(tableName) {
+  const row = db.prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?").get(tableName);
+  return row?.sql?.includes('users_legacy') ?? false;
+}
+
+function rebuildUserForeignKeyTablesIfNeeded() {
+  const rebuildSessions = tableReferencesLegacyUsers('sessions');
+  const rebuildFeatureFlags = tableReferencesLegacyUsers('feature_flags');
+  const rebuildAuditEvents = tableReferencesLegacyUsers('audit_events');
+
+  if (!rebuildSessions && !rebuildFeatureFlags && !rebuildAuditEvents) {
+    return;
+  }
+
+  const rebuildTables = db.transaction(() => {
+    db.pragma('foreign_keys = OFF');
+
+    if (rebuildSessions) {
+      db.exec(`CREATE TABLE sessions_new ${SESSIONS_TABLE_BODY}`);
+      db.exec(`
+        INSERT INTO sessions_new (token, user_id, created_at, expires_at)
+        SELECT token, user_id, created_at, expires_at
+        FROM sessions
+      `);
+      db.exec('DROP TABLE sessions');
+      db.exec('ALTER TABLE sessions_new RENAME TO sessions');
+    }
+
+    if (rebuildFeatureFlags) {
+      db.exec(`CREATE TABLE feature_flags_new ${FEATURE_FLAGS_TABLE_BODY}`);
+      db.exec(`
+        INSERT INTO feature_flags_new (key, enabled, description, updated_at, updated_by_user_id)
+        SELECT key, enabled, description, updated_at, updated_by_user_id
+        FROM feature_flags
+      `);
+      db.exec('DROP TABLE feature_flags');
+      db.exec('ALTER TABLE feature_flags_new RENAME TO feature_flags');
+    }
+
+    if (rebuildAuditEvents) {
+      db.exec(`CREATE TABLE audit_events_new ${AUDIT_EVENTS_TABLE_BODY}`);
+      db.exec(`
+        INSERT INTO audit_events_new (
+          id, event_type, level, actor_user_id, target_user_id, request_id, message, metadata_json, created_at
+        )
+        SELECT
+          id, event_type, level, actor_user_id, target_user_id, request_id, message, metadata_json, created_at
+        FROM audit_events
+      `);
+      db.exec('DROP TABLE audit_events');
+      db.exec('ALTER TABLE audit_events_new RENAME TO audit_events');
+    }
+
+    db.pragma('foreign_keys = ON');
+  });
+
+  rebuildTables();
+}
+
+rebuildUserForeignKeyTablesIfNeeded();
+
+const sessionColumns = db.prepare('PRAGMA table_info(sessions)').all();
 
 if (!sessionColumns.some((column) => column.name === 'expires_at')) {
   db.exec('ALTER TABLE sessions ADD COLUMN expires_at TEXT');
@@ -77,6 +220,8 @@ if (!sessionColumns.some((column) => column.name === 'expires_at')) {
 
 db.exec(`
   CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
+  CREATE INDEX IF NOT EXISTS idx_users_account_status ON users(account_status);
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_users_auth_identity ON users(auth_provider, auth_subject);
   CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
   CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);
   CREATE INDEX IF NOT EXISTS idx_audit_events_created_at ON audit_events(created_at DESC);

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,14 @@
 import crypto from 'node:crypto';
-import bcrypt from 'bcryptjs';
 import express from 'express';
+import {
+  assertPasswordAuthEnabled,
+  buildLocalIdentity,
+  canUsePasswordAuth,
+  getAuthConfig,
+  hashPassword,
+  normalizeEmail,
+  verifyPassword,
+} from './auth.js';
 import db from './db.js';
 import { buildDefaultState, normalizeState } from './defaultState.js';
 
@@ -8,6 +16,7 @@ const app = express();
 const PORT = 3001;
 const SESSION_COOKIE = 'focus_flow_session';
 const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 30;
+const COOKIE_SECURE = process.env.COOKIE_SECURE === 'true';
 const ADMIN_EMAILS = new Set(
   String(process.env.ADMIN_EMAILS ?? '')
     .split(',')
@@ -95,12 +104,12 @@ function parseCookies(cookieHeader = '') {
 function setSessionCookie(res, token) {
   res.setHeader(
     'Set-Cookie',
-    `${SESSION_COOKIE}=${encodeURIComponent(token)}; HttpOnly; Path=/; SameSite=Lax; Max-Age=${60 * 60 * 24 * 30}; Priority=High`
+    `${SESSION_COOKIE}=${encodeURIComponent(token)}; HttpOnly; Path=/; SameSite=Lax; Max-Age=${60 * 60 * 24 * 30}; Priority=High${COOKIE_SECURE ? '; Secure' : ''}`
   );
 }
 
 function clearSessionCookie(res) {
-  res.setHeader('Set-Cookie', `${SESSION_COOKIE}=; HttpOnly; Path=/; SameSite=Lax; Max-Age=0`);
+  res.setHeader('Set-Cookie', `${SESSION_COOKIE}=; HttpOnly; Path=/; SameSite=Lax; Max-Age=0${COOKIE_SECURE ? '; Secure' : ''}`);
 }
 
 function publicUser(row) {
@@ -109,6 +118,8 @@ function publicUser(row) {
     email: row.email,
     displayName: row.display_name,
     role: row.role,
+    authProvider: row.auth_provider ?? 'local',
+    accountStatus: row.account_status ?? 'active',
   };
 }
 
@@ -133,6 +144,15 @@ function parseJsonSafely(value, fallback = null) {
   } catch {
     return fallback;
   }
+}
+
+function authResponseForUser(user, settingsJson = user.settings_json) {
+  return {
+    user: publicUser(user),
+    settings: parseStoredSettings(settingsJson),
+    featureFlags: getFeatureFlags(),
+    auth: getAuthConfig(),
+  };
 }
 
 function getFeatureFlags() {
@@ -190,12 +210,21 @@ function purgeExpiredSessions(nowIso = new Date().toISOString()) {
   db.prepare('DELETE FROM sessions WHERE expires_at IS NOT NULL AND expires_at <= ?').run(nowIso);
 }
 
+function nextSessionExpiry(baseDate = new Date()) {
+  return new Date(baseDate.getTime() + SESSION_TTL_MS).toISOString();
+}
+
 function createSession(userId) {
   const createdAt = new Date();
   const token = crypto.randomUUID();
   db.prepare('INSERT INTO sessions (token, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)')
-    .run(token, userId, createdAt.toISOString(), new Date(createdAt.getTime() + SESSION_TTL_MS).toISOString());
+    .run(token, userId, createdAt.toISOString(), nextSessionExpiry(createdAt));
   return token;
+}
+
+function refreshSession(token) {
+  db.prepare('UPDATE sessions SET expires_at = ? WHERE token = ?')
+    .run(nextSessionExpiry(), token);
 }
 
 function requireAuth(req, res, next) {
@@ -210,7 +239,8 @@ function requireAuth(req, res, next) {
   const nowIso = new Date().toISOString();
   const row = db
     .prepare(
-      `SELECT users.id, users.email, users.display_name, users.role, users.settings_json
+      `SELECT users.id, users.email, users.display_name, users.role, users.auth_provider, users.auth_subject,
+              users.account_status, users.settings_json
        FROM sessions
        JOIN users ON users.id = sessions.user_id
        WHERE sessions.token = ?
@@ -223,8 +253,16 @@ function requireAuth(req, res, next) {
     return res.status(401).json({ error: 'Session expired.' });
   }
 
+  if (row.account_status !== 'active') {
+    db.prepare('DELETE FROM sessions WHERE token = ?').run(token);
+    clearSessionCookie(res);
+    return res.status(403).json({ error: 'Account access is unavailable.' });
+  }
+
   req.user = row;
   req.sessionToken = token;
+  refreshSession(token);
+  setSessionCookie(res, token);
   next();
 }
 
@@ -272,8 +310,13 @@ app.get('/api/health', (_req, res) => {
   res.json({ ok: true });
 });
 
+app.get('/api/auth/config', (_req, res) => {
+  res.json({ auth: getAuthConfig() });
+});
+
 app.post('/api/auth/register', (req, res) => {
-  const email = String(req.body?.email ?? '').trim().toLowerCase();
+  assertPasswordAuthEnabled();
+  const email = normalizeEmail(req.body?.email);
   const password = String(req.body?.password ?? '');
   const displayName = String(req.body?.displayName ?? '').trim();
 
@@ -291,21 +334,23 @@ app.post('/api/auth/register', (req, res) => {
   }
 
   const id = crypto.randomUUID();
-  const passwordHash = bcrypt.hashSync(password, 10);
+  const passwordHash = hashPassword(password);
   const settings = JSON.stringify(buildDefaultState());
   const role = getUserRole(email);
+  const identity = buildLocalIdentity(email);
 
   db.prepare(
-    `INSERT INTO users (id, email, password_hash, display_name, role, settings_json, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`
-  ).run(id, email, passwordHash, displayName, role, settings, new Date().toISOString());
+    `INSERT INTO users (
+      id, email, password_hash, display_name, role, auth_provider, auth_subject, account_status, settings_json, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(id, email, passwordHash, displayName, role, identity.authProvider, identity.authSubject, 'active', settings, new Date().toISOString());
 
   const token = createSession(id);
 
   setSessionCookie(res, token);
 
   const user = db
-    .prepare('SELECT id, email, display_name, role FROM users WHERE id = ?')
+    .prepare('SELECT id, email, display_name, role, auth_provider, auth_subject, account_status, settings_json FROM users WHERE id = ?')
     .get(id);
 
   writeAuditEvent({
@@ -316,22 +361,23 @@ app.post('/api/auth/register', (req, res) => {
     metadata: { role },
   });
 
-  return res.status(201).json({
-    user: publicUser(user),
-    settings: parseStoredSettings(settings),
-    featureFlags: getFeatureFlags(),
-  });
+  return res.status(201).json(authResponseForUser(user, settings));
 });
 
 app.post('/api/auth/login', (req, res) => {
-  const email = String(req.body?.email ?? '').trim().toLowerCase();
+  assertPasswordAuthEnabled();
+  const email = normalizeEmail(req.body?.email);
   const password = String(req.body?.password ?? '');
 
   const user = db
-    .prepare('SELECT id, email, display_name, role, password_hash, settings_json FROM users WHERE email = ?')
+    .prepare(
+      `SELECT id, email, display_name, role, password_hash, auth_provider, auth_subject, account_status, settings_json
+       FROM users
+       WHERE email = ?`
+    )
     .get(email);
 
-  if (!user || !bcrypt.compareSync(password, user.password_hash)) {
+  if (!user || user.account_status !== 'active' || !canUsePasswordAuth(user) || !verifyPassword(password, user.password_hash)) {
     writeAuditEvent({
       eventType: 'auth.login_failed',
       level: 'warn',
@@ -346,6 +392,7 @@ app.post('/api/auth/login', (req, res) => {
     db.prepare('UPDATE users SET role = ? WHERE id = ?').run(resolvedRole, user.id);
     user.role = resolvedRole;
   }
+  db.prepare('UPDATE users SET last_login_at = ? WHERE id = ?').run(new Date().toISOString(), user.id);
   const token = createSession(user.id);
 
   setSessionCookie(res, token);
@@ -357,11 +404,7 @@ app.post('/api/auth/login', (req, res) => {
     message: `User logged in: ${user.email}`,
   });
 
-  return res.json({
-    user: publicUser(user),
-    settings: parseStoredSettings(user.settings_json),
-    featureFlags: getFeatureFlags(),
-  });
+  return res.json(authResponseForUser(user));
 });
 
 app.post('/api/auth/logout', requireAuth, (req, res) => {
@@ -382,11 +425,7 @@ app.get('/api/auth/session', requireAuth, (req, res) => {
     db.prepare('UPDATE users SET role = ? WHERE id = ?').run(resolvedRole, req.user.id);
     req.user.role = resolvedRole;
   }
-  res.json({
-    user: publicUser(req.user),
-    settings: parseStoredSettings(req.user.settings_json),
-    featureFlags: getFeatureFlags(),
-  });
+  res.json(authResponseForUser(req.user));
 });
 
 app.put('/api/settings', requireAuth, (req, res) => {
@@ -433,7 +472,9 @@ app.get('/api/admin/summary', requireAuth, requireAdmin, (_req, res) => {
   const counts = db.prepare(`
     SELECT
       COUNT(*) AS totalUsers,
-      SUM(CASE WHEN role = 'admin' THEN 1 ELSE 0 END) AS adminUsers
+      SUM(CASE WHEN role = 'admin' THEN 1 ELSE 0 END) AS adminUsers,
+      SUM(CASE WHEN auth_provider = 'local' THEN 1 ELSE 0 END) AS localUsers,
+      SUM(CASE WHEN account_status = 'active' THEN 1 ELSE 0 END) AS activeUsers
     FROM users
   `).get();
   const recentEvents = db.prepare(`
@@ -458,15 +499,18 @@ app.get('/api/admin/summary', requireAuth, requireAdmin, (_req, res) => {
     metrics: {
       totalUsers: Number(counts.totalUsers ?? 0),
       adminUsers: Number(counts.adminUsers ?? 0),
+      localUsers: Number(counts.localUsers ?? 0),
+      activeUsers: Number(counts.activeUsers ?? 0),
     },
     recentEvents,
+    auth: getAuthConfig(),
   });
 });
 
 app.get('/api/admin/users', requireAuth, requireAdmin, (req, res) => {
   const query = String(req.query.query ?? '').trim().toLowerCase();
   const sql = `
-    SELECT id, email, display_name, role, created_at
+    SELECT id, email, display_name, role, auth_provider, account_status, created_at, last_login_at
     FROM users
     WHERE (? = '' OR lower(email) LIKE ? OR lower(display_name) LIKE ?)
     ORDER BY created_at DESC
@@ -478,7 +522,10 @@ app.get('/api/admin/users', requireAuth, requireAdmin, (req, res) => {
     email: row.email,
     displayName: row.display_name,
     role: row.role,
+    authProvider: row.auth_provider,
+    accountStatus: row.account_status,
     createdAt: row.created_at,
+    lastLoginAt: row.last_login_at,
   }));
 
   res.json({ users });
@@ -601,9 +648,10 @@ app.get('/api/context/brief', requireAuth, async (req, res) => {
 });
 
 app.use((error, req, res, _next) => {
+  const statusCode = Number.isInteger(error?.statusCode) ? error.statusCode : 500;
   writeAuditEvent({
-    eventType: 'server.error',
-    level: 'error',
+    eventType: statusCode >= 500 ? 'server.error' : 'server.warning',
+    level: statusCode >= 500 ? 'error' : 'warn',
     actorUserId: req.user?.id ?? null,
     requestId: req.requestId ?? null,
     message: String(error?.message ?? error ?? 'Unhandled server error'),
@@ -612,7 +660,7 @@ app.use((error, req, res, _next) => {
   if (res.headersSent) {
     return;
   }
-  res.status(500).json({ error: 'Internal server error.' });
+  res.status(statusCode).json({ error: statusCode >= 500 ? 'Internal server error.' : String(error?.message ?? 'Request failed.') });
 });
 
 app.listen(PORT, () => {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { AuthScreen } from './components/AuthScreen.jsx';
 import { OnboardingFlow } from './components/OnboardingFlow.jsx';
+import { useAdminData } from './hooks/useAdminData.js';
+import { useAuthSession } from './hooks/useAuthSession.js';
 import { api, reportClientError } from './lib/api.js';
 import {
   createTask,
@@ -17,7 +19,6 @@ import {
   circadianWindow,
 } from './lib/focusFlowCore.js';
 import {
-  DEFAULT_FEATURE_FLAGS,
   DEFAULT_SETTINGS,
   GOAL_OPTIONS,
   ROUTINE_OPTIONS,
@@ -28,21 +29,12 @@ import { ProfileView } from './views/ProfileView.jsx';
 import { SettingsView } from './views/SettingsView.jsx';
 
 export default function App() {
-  const [authChecked, setAuthChecked] = useState(false);
-  const [authMode, setAuthMode] = useState('login');
-  const [authPending, setAuthPending] = useState(false);
-  const [authError, setAuthError] = useState('');
-  const [user, setUser] = useState(null);
-  const [settings, setSettings] = useState(DEFAULT_SETTINGS);
-  const [featureFlags, setFeatureFlags] = useState(DEFAULT_FEATURE_FLAGS);
   const [saveStatus, setSaveStatus] = useState('Not saved yet');
   const [siteView, setSiteView] = useState('planner');
   const [menuOpen, setMenuOpen] = useState(false);
   const [phaseRemaining, setPhaseRemaining] = useState(DEFAULT_SETTINGS.phases[0].defaultMinutes * 60);
   const [phaseRunning, setPhaseRunning] = useState(false);
   const [taskTimers, setTaskTimers] = useState({});
-  const browserTimeZone = getBrowserTimeZone();
-  const todayKey = getDateKey(settings.preferences?.timeZone || browserTimeZone);
   const [checkInDone, setCheckInDone] = useState(false);
   const [collapsedPhases, setCollapsedPhases] = useState(
     () => new Set(DEFAULT_SETTINGS.phases.map((p) => p.id).filter((id) => id !== DEFAULT_SETTINGS.activePhaseId))
@@ -61,21 +53,49 @@ export default function App() {
   const [onboardingStep, setOnboardingStep] = useState(0);
   const [wakeHour, setWakeHour] = useState(null);
   const [profileExpanded, setProfileExpanded] = useState(false);
-  const [adminSummary, setAdminSummary] = useState({ flags: DEFAULT_FEATURE_FLAGS, metrics: null, recentEvents: [] });
-  const [adminUsers, setAdminUsers] = useState([]);
-  const [adminQuery, setAdminQuery] = useState('');
-  const [adminLoading, setAdminLoading] = useState(false);
-  const [adminStatus, setAdminStatus] = useState('');
-  const [authForm, setAuthForm] = useState({
-    displayName: '',
-    email: '',
-    password: '',
-  });
   const phaseIntervalRef = useRef(null);
   const saveTimeoutRef = useRef(null);
   const menuRef = useRef(null);
-  const loadedSettingsRef = useRef(false);
   const locationTriedRef = useRef(false);
+  const {
+    authChecked,
+    authMode,
+    setAuthMode,
+    authPending,
+    authError,
+    authForm,
+    authConfig,
+    user,
+    settings,
+    setSettings,
+    featureFlags,
+    setFeatureFlags,
+    loadedSettingsRef,
+    handleAuthSubmit,
+    handleLogout,
+    updateAuthForm,
+  } = useAuthSession({
+    onAuthenticated: () => setSaveStatus('All changes saved'),
+    onSignedOut: () => setSaveStatus('Signed out'),
+  });
+  const browserTimeZone = getBrowserTimeZone();
+  const todayKey = getDateKey(settings.preferences?.timeZone || browserTimeZone);
+  const {
+    adminSummary,
+    adminUsers,
+    adminQuery,
+    adminLoading,
+    adminStatus,
+    setAdminQuery,
+    refreshAdminSummary,
+    searchAdminUsers,
+    toggleFeatureFlag,
+    resetUserState,
+  } = useAdminData({
+    user,
+    siteView,
+    onFeatureFlagsChange: setFeatureFlags,
+  });
 
   const activePhase = useMemo(
     () => settings.phases.find((phase) => phase.id === settings.activePhaseId) ?? settings.phases[0],
@@ -95,34 +115,6 @@ export default function App() {
     }
     return () => window.removeEventListener('mousedown', onDocumentClick);
   }, [menuOpen]);
-
-  useEffect(() => {
-    let cancelled = false;
-    api('/api/auth/session')
-      .then((data) => {
-        if (cancelled) {
-          return;
-        }
-        setUser(data.user);
-        setSettings(data.settings);
-        setFeatureFlags(data.featureFlags ?? DEFAULT_FEATURE_FLAGS);
-        setSaveStatus('All changes saved');
-        loadedSettingsRef.current = true;
-      })
-      .catch(() => {
-        if (!cancelled) {
-          loadedSettingsRef.current = false;
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setAuthChecked(true);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   useEffect(() => {
     if (!user) {
@@ -345,15 +337,6 @@ export default function App() {
     setSettings((current) => ({ ...current, ...patch }));
   }
 
-  function updateActivePhase(patch) {
-    setSettings((current) => ({
-      ...current,
-      phases: current.phases.map((phase) =>
-        phase.id === current.activePhaseId ? { ...phase, ...patch } : phase
-      ),
-    }));
-  }
-
   function updateTasksInPhase(phaseId, updater) {
     setSettings((current) => ({
       ...current,
@@ -361,45 +344,6 @@ export default function App() {
         phase.id === phaseId ? { ...phase, tasks: updater(phase.tasks ?? []) } : phase
       ),
     }));
-  }
-
-  async function handleAuthSubmit(event) {
-    event.preventDefault();
-    setAuthPending(true);
-    setAuthError('');
-    try {
-      const path = authMode === 'login' ? '/api/auth/login' : '/api/auth/register';
-      const data = await api(path, {
-        method: 'POST',
-        body: JSON.stringify(authForm),
-      });
-      setUser(data.user);
-      setSettings(data.settings);
-      setFeatureFlags(data.featureFlags ?? DEFAULT_FEATURE_FLAGS);
-      loadedSettingsRef.current = true;
-      setAuthChecked(true);
-      setAuthForm({ displayName: '', email: '', password: '' });
-      setSaveStatus('All changes saved');
-    } catch (error) {
-      setAuthError(error.message);
-    } finally {
-      setAuthPending(false);
-    }
-  }
-
-  async function handleLogout() {
-    try {
-      await api('/api/auth/logout', { method: 'POST' });
-    } catch {
-      // ignore
-    }
-    loadedSettingsRef.current = false;
-    setUser(null);
-    setSettings(DEFAULT_SETTINGS);
-    setFeatureFlags(DEFAULT_FEATURE_FLAGS);
-    setAuthMode('login');
-    setAuthError('');
-    setSaveStatus('Signed out');
   }
 
   function handleStartPhase() {
@@ -631,22 +575,6 @@ export default function App() {
     setSettingsPatch({ routineType: nextType });
   }
 
-  function refreshContext() {
-    const lat = settings.preferences?.location?.latitude;
-    const lon = settings.preferences?.location?.longitude;
-    const timeZone = settings.preferences?.timeZone || 'UTC';
-    const params = new URLSearchParams({ timeZone });
-    if (Number.isFinite(lat) && Number.isFinite(lon)) {
-      params.set('lat', String(lat));
-      params.set('lon', String(lon));
-    }
-
-    setMindContext((current) => ({ ...current, loading: true, error: '' }));
-    api(`/api/context/brief?${params.toString()}`)
-      .then((data) => setMindContext({ loading: false, data, error: '' }))
-      .catch((error) => setMindContext({ loading: false, data: null, error: error.message }));
-  }
-
   function syncLocationNow() {
     if (!navigator.geolocation) {
       setLocationStatus('Geolocation is not available in this browser.');
@@ -674,77 +602,6 @@ export default function App() {
     );
   }
 
-  async function refreshAdminSummary() {
-    if (user?.role !== 'admin') {
-      return;
-    }
-    setAdminLoading(true);
-    setAdminStatus('');
-    try {
-      const data = await api('/api/admin/summary');
-      setAdminSummary(data);
-      setFeatureFlags(data.flags ?? DEFAULT_FEATURE_FLAGS);
-    } catch (error) {
-      setAdminStatus(error.message);
-    } finally {
-      setAdminLoading(false);
-    }
-  }
-
-  async function searchAdminUsers(nextQuery = adminQuery) {
-    if (user?.role !== 'admin') {
-      return;
-    }
-    setAdminLoading(true);
-    setAdminStatus('');
-    try {
-      const params = new URLSearchParams();
-      if (nextQuery.trim()) {
-        params.set('query', nextQuery.trim());
-      }
-      const data = await api(`/api/admin/users${params.toString() ? `?${params.toString()}` : ''}`);
-      setAdminUsers(data.users ?? []);
-    } catch (error) {
-      setAdminStatus(error.message);
-    } finally {
-      setAdminLoading(false);
-    }
-  }
-
-  async function toggleFeatureFlag(key, enabled) {
-    setAdminStatus('');
-    try {
-      const data = await api(`/api/admin/flags/${encodeURIComponent(key)}`, {
-        method: 'PUT',
-        body: JSON.stringify({ enabled }),
-      });
-      setFeatureFlags(data.flags ?? DEFAULT_FEATURE_FLAGS);
-      setAdminSummary((current) => ({ ...current, flags: data.flags ?? DEFAULT_FEATURE_FLAGS }));
-    } catch (error) {
-      setAdminStatus(error.message);
-    }
-  }
-
-  async function resetUserState(targetUserId) {
-    setAdminStatus('');
-    try {
-      await api(`/api/admin/users/${encodeURIComponent(targetUserId)}/reset`, {
-        method: 'POST',
-      });
-      setAdminStatus('User state reset.');
-      await Promise.all([refreshAdminSummary(), searchAdminUsers()]);
-    } catch (error) {
-      setAdminStatus(error.message);
-    }
-  }
-
-  useEffect(() => {
-    if (siteView === 'admin' && user?.role === 'admin') {
-      refreshAdminSummary();
-      searchAdminUsers('');
-    }
-  }, [siteView, user?.role]);
-
   useEffect(() => {
     if (!isFeatureEnabled('cycle_tracking') && onboardingStep === 1) {
       setOnboardingStep(2);
@@ -767,13 +624,9 @@ export default function App() {
       <AuthScreen
         mode={authMode}
         form={authForm}
+        authConfig={authConfig}
         onModeChange={setAuthMode}
-        onChange={(event) =>
-          setAuthForm((current) => ({
-            ...current,
-            [event.target.name]: event.target.value,
-          }))
-        }
+        onChange={updateAuthForm}
         onSubmit={handleAuthSubmit}
         authPending={authPending}
         authError={authError}

--- a/src/components/AuthScreen.jsx
+++ b/src/components/AuthScreen.jsx
@@ -1,4 +1,6 @@
-export function AuthScreen({ mode, form, onModeChange, onChange, onSubmit, authPending, authError }) {
+export function AuthScreen({ mode, form, authConfig, onModeChange, onChange, onSubmit, authPending, authError }) {
+  const usesManagedAuth = authConfig?.mode === 'managed';
+
   return (
     <main className="auth-shell">
       <section className="auth-card">
@@ -6,21 +8,25 @@ export function AuthScreen({ mode, form, onModeChange, onChange, onSubmit, authP
           <p className="eyebrow">Focus Flow</p>
           <h1>Sign in to your rhythm</h1>
           <p className="lede">
-            Your phase setup, routines, and mind-check context are saved to your local account.
+            {usesManagedAuth
+              ? 'This environment is configured for managed sign-in. Local password sign-up is disabled here.'
+              : 'Your phase setup, routines, and mind-check context are saved to your local account.'}
           </p>
         </div>
 
-        <div className="auth-toggle">
-          <button className={mode === 'login' ? 'active-tab' : 'ghost'} onClick={() => onModeChange('login')} type="button">
-            Sign in
-          </button>
-          <button className={mode === 'register' ? 'active-tab' : 'ghost'} onClick={() => onModeChange('register')} type="button">
-            Create account
-          </button>
-        </div>
+        {!usesManagedAuth && (
+          <div className="auth-toggle">
+            <button className={mode === 'login' ? 'active-tab' : 'ghost'} onClick={() => onModeChange('login')} type="button">
+              Sign in
+            </button>
+            <button className={mode === 'register' ? 'active-tab' : 'ghost'} onClick={() => onModeChange('register')} type="button">
+              Create account
+            </button>
+          </div>
+        )}
 
         <form className="auth-form" onSubmit={onSubmit}>
-          {mode === 'register' && (
+          {mode === 'register' && !usesManagedAuth && (
             <label>
               Name
               <input name="displayName" value={form.displayName} onChange={onChange} placeholder="Alex" autoComplete="name" />
@@ -41,8 +47,13 @@ export function AuthScreen({ mode, form, onModeChange, onChange, onSubmit, authP
               autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
             />
           </label>
+          {usesManagedAuth && (
+            <p className="muted-copy">
+              Managed auth provider: {authConfig?.managedProvider ?? 'external'}
+            </p>
+          )}
           {authError && <p className="status-message error">{authError}</p>}
-          <button type="submit" disabled={authPending}>
+          <button type="submit" disabled={authPending || usesManagedAuth}>
             {authPending ? 'Working...' : mode === 'login' ? 'Sign in' : 'Create account'}
           </button>
         </form>

--- a/src/hooks/useAdminData.js
+++ b/src/hooks/useAdminData.js
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api.js';
+import { DEFAULT_FEATURE_FLAGS } from '../lib/focusFlowData.js';
+
+export function useAdminData({ user, siteView, onFeatureFlagsChange }) {
+  const [adminSummary, setAdminSummary] = useState({
+    flags: DEFAULT_FEATURE_FLAGS,
+    metrics: null,
+    recentEvents: [],
+    auth: null,
+  });
+  const [adminUsers, setAdminUsers] = useState([]);
+  const [adminQuery, setAdminQuery] = useState('');
+  const [adminLoading, setAdminLoading] = useState(false);
+  const [adminStatus, setAdminStatus] = useState('');
+
+  async function refreshAdminSummary() {
+    if (user?.role !== 'admin') {
+      return;
+    }
+    setAdminLoading(true);
+    setAdminStatus('');
+    try {
+      const data = await api('/api/admin/summary');
+      setAdminSummary(data);
+      onFeatureFlagsChange?.(data.flags ?? DEFAULT_FEATURE_FLAGS);
+    } catch (error) {
+      setAdminStatus(error.message);
+    } finally {
+      setAdminLoading(false);
+    }
+  }
+
+  async function searchAdminUsers(nextQuery = adminQuery) {
+    if (user?.role !== 'admin') {
+      return;
+    }
+    setAdminLoading(true);
+    setAdminStatus('');
+    try {
+      const params = new URLSearchParams();
+      if (nextQuery.trim()) {
+        params.set('query', nextQuery.trim());
+      }
+      const data = await api(`/api/admin/users${params.toString() ? `?${params.toString()}` : ''}`);
+      setAdminUsers(data.users ?? []);
+    } catch (error) {
+      setAdminStatus(error.message);
+    } finally {
+      setAdminLoading(false);
+    }
+  }
+
+  async function toggleFeatureFlag(key, enabled) {
+    setAdminStatus('');
+    try {
+      const data = await api(`/api/admin/flags/${encodeURIComponent(key)}`, {
+        method: 'PUT',
+        body: JSON.stringify({ enabled }),
+      });
+      onFeatureFlagsChange?.(data.flags ?? DEFAULT_FEATURE_FLAGS);
+      setAdminSummary((current) => ({
+        ...current,
+        flags: data.flags ?? DEFAULT_FEATURE_FLAGS,
+      }));
+    } catch (error) {
+      setAdminStatus(error.message);
+    }
+  }
+
+  async function resetUserState(targetUserId) {
+    setAdminStatus('');
+    try {
+      await api(`/api/admin/users/${encodeURIComponent(targetUserId)}/reset`, {
+        method: 'POST',
+      });
+      setAdminStatus('User state reset.');
+      await Promise.all([refreshAdminSummary(), searchAdminUsers()]);
+    } catch (error) {
+      setAdminStatus(error.message);
+    }
+  }
+
+  useEffect(() => {
+    if (siteView === 'admin' && user?.role === 'admin') {
+      refreshAdminSummary();
+      searchAdminUsers('');
+    }
+  }, [siteView, user?.role]);
+
+  return {
+    adminSummary,
+    adminUsers,
+    adminQuery,
+    adminLoading,
+    adminStatus,
+    setAdminQuery,
+    refreshAdminSummary,
+    searchAdminUsers,
+    toggleFeatureFlag,
+    resetUserState,
+  };
+}

--- a/src/hooks/useAuthSession.js
+++ b/src/hooks/useAuthSession.js
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from 'react';
+import { api } from '../lib/api.js';
+import { DEFAULT_FEATURE_FLAGS, DEFAULT_SETTINGS } from '../lib/focusFlowData.js';
+
+const DEFAULT_AUTH_FORM = {
+  displayName: '',
+  email: '',
+  password: '',
+};
+
+const DEFAULT_AUTH_CONFIG = {
+  mode: 'local',
+  passwordSignInEnabled: true,
+  registrationEnabled: true,
+  managedProvider: null,
+};
+
+export function useAuthSession({ onAuthenticated, onSignedOut } = {}) {
+  const [authChecked, setAuthChecked] = useState(false);
+  const [authMode, setAuthMode] = useState('login');
+  const [authPending, setAuthPending] = useState(false);
+  const [authError, setAuthError] = useState('');
+  const [authForm, setAuthForm] = useState(DEFAULT_AUTH_FORM);
+  const [authConfig, setAuthConfig] = useState(DEFAULT_AUTH_CONFIG);
+  const [user, setUser] = useState(null);
+  const [settings, setSettings] = useState(DEFAULT_SETTINGS);
+  const [featureFlags, setFeatureFlags] = useState(DEFAULT_FEATURE_FLAGS);
+  const loadedSettingsRef = useRef(false);
+  const onAuthenticatedRef = useRef(onAuthenticated);
+  const onSignedOutRef = useRef(onSignedOut);
+
+  useEffect(() => {
+    onAuthenticatedRef.current = onAuthenticated;
+  }, [onAuthenticated]);
+
+  useEffect(() => {
+    onSignedOutRef.current = onSignedOut;
+  }, [onSignedOut]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function bootstrapSession() {
+      const authMeta = await api('/api/auth/config')
+        .then((data) => data?.auth ?? DEFAULT_AUTH_CONFIG)
+        .catch(() => DEFAULT_AUTH_CONFIG);
+
+      if (!cancelled) {
+        setAuthConfig(authMeta);
+      }
+
+      try {
+        const data = await api('/api/auth/session');
+        if (cancelled) {
+          return;
+        }
+        setUser(data.user);
+        setSettings(data.settings);
+        setFeatureFlags(data.featureFlags ?? DEFAULT_FEATURE_FLAGS);
+        setAuthConfig(data.auth ?? authMeta);
+        loadedSettingsRef.current = true;
+        onAuthenticatedRef.current?.(data);
+      } catch {
+        if (!cancelled) {
+          loadedSettingsRef.current = false;
+        }
+      } finally {
+        if (!cancelled) {
+          setAuthChecked(true);
+        }
+      }
+    }
+
+    bootstrapSession();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleAuthSubmit(event) {
+    event.preventDefault();
+    if (!authConfig.passwordSignInEnabled) {
+      setAuthError('Password sign-in is disabled for this environment.');
+      return;
+    }
+    setAuthPending(true);
+    setAuthError('');
+    try {
+      const path = authMode === 'login' ? '/api/auth/login' : '/api/auth/register';
+      const data = await api(path, {
+        method: 'POST',
+        body: JSON.stringify(authForm),
+      });
+      setUser(data.user);
+      setSettings(data.settings);
+      setFeatureFlags(data.featureFlags ?? DEFAULT_FEATURE_FLAGS);
+      setAuthConfig(data.auth ?? DEFAULT_AUTH_CONFIG);
+      loadedSettingsRef.current = true;
+      setAuthChecked(true);
+      setAuthForm(DEFAULT_AUTH_FORM);
+      onAuthenticatedRef.current?.(data);
+    } catch (error) {
+      setAuthError(error.message);
+    } finally {
+      setAuthPending(false);
+    }
+  }
+
+  async function handleLogout() {
+    try {
+      await api('/api/auth/logout', { method: 'POST' });
+    } catch {
+      // ignore logout failures and clear local state
+    }
+    loadedSettingsRef.current = false;
+    setUser(null);
+    setSettings(DEFAULT_SETTINGS);
+    setFeatureFlags(DEFAULT_FEATURE_FLAGS);
+    setAuthMode('login');
+    setAuthError('');
+    onSignedOutRef.current?.();
+  }
+
+  function updateAuthForm(event) {
+    setAuthForm((current) => ({
+      ...current,
+      [event.target.name]: event.target.value,
+    }));
+  }
+
+  return {
+    authChecked,
+    authMode,
+    setAuthMode,
+    authPending,
+    authError,
+    authForm,
+    authConfig,
+    user,
+    settings,
+    setSettings,
+    featureFlags,
+    setFeatureFlags,
+    loadedSettingsRef,
+    handleAuthSubmit,
+    handleLogout,
+    updateAuthForm,
+  };
+}

--- a/src/views/AdminView.jsx
+++ b/src/views/AdminView.jsx
@@ -54,10 +54,22 @@ export function AdminView({
             <strong>{adminSummary.metrics?.adminUsers ?? 0}</strong>
           </div>
           <div className="admin-metric">
+            <span>Local auth users</span>
+            <strong>{adminSummary.metrics?.localUsers ?? 0}</strong>
+          </div>
+          <div className="admin-metric">
+            <span>Active accounts</span>
+            <strong>{adminSummary.metrics?.activeUsers ?? 0}</strong>
+          </div>
+          <div className="admin-metric">
             <span>Flags</span>
             <strong>{(adminSummary.flags ?? featureFlags).length}</strong>
           </div>
         </div>
+        <p className="muted-copy" style={{ marginTop: '0.75rem' }}>
+          Auth mode: {adminSummary.auth?.mode ?? 'local'}
+          {adminSummary.auth?.managedProvider ? ` · ${adminSummary.auth.managedProvider}` : ''}
+        </p>
       </div>
 
       <div className="admin-section">
@@ -87,7 +99,12 @@ export function AdminView({
             <div key={adminUser.id} className="admin-user-row">
               <div>
                 <strong>{adminUser.displayName}</strong>
-                <p className="muted-copy">{adminUser.email} · {adminUser.role}</p>
+                <p className="muted-copy">
+                  {adminUser.email} · {adminUser.role} · {adminUser.authProvider} · {adminUser.accountStatus}
+                </p>
+                {adminUser.lastLoginAt && (
+                  <p className="muted-copy">Last login {new Date(adminUser.lastLoginAt).toLocaleString()}</p>
+                )}
               </div>
               <button
                 className="ghost small"


### PR DESCRIPTION
## Summary
- add a provider-aware auth model with explicit auth provider, subject, and account status fields
- add a local-vs-managed auth seam plus sliding session refresh on authenticated requests
- move frontend auth and admin state into dedicated hooks and expose auth mode details in the UI/admin panel

## Testing
- npm run build
- node --check server/server.js
- node --check server/auth.js
- node --check server/db.js
- node --input-type=module -e "import './server/db.js'; import './server/auth.js'; console.log('server modules ok')"