### PR TITLE
Admin testing utilities and bootstrap admin access

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -71,6 +71,8 @@ The current tone should stay calm, practical, and non-shaming. Guidance should f
 - SQLite/runtime artifacts should never be committed
 - Security posture is still lightweight because this is a local-first prototype, but obvious gaps should still be closed
 - Local admin/operator controls now live in-app and are meant to evolve into a hosted admin plane later
+- Admin tools currently include feature flags, user inspect, suspend/reactivate, revoke sessions, reset state, demo seeding, and activity clearing
+- In local auth mode, if no admin exists yet, a signed-in user can claim admin from the Profile page
 - Near-term hosted direction assumes managed auth, but local development can keep first-party auth as a stand-in
 - User identity now has explicit provider/status fields so hosted auth can migrate without another schema rewrite
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,17 @@ npm run dev
 - Local admin access is controlled by the `ADMIN_EMAILS` environment variable.
 - Example: `ADMIN_EMAILS=you@example.com,teammate@example.com`
 - Matching users are elevated to the `admin` role on register/login/session refresh.
+- If no admin exists yet in local auth mode, a signed-in user can claim admin access from the Profile page.
 - Admins get an in-app Admin page for:
   - toggling feature flags
   - viewing recent audit/error events
   - searching users
-  - resetting a test user's saved state and sessions
+  - inspecting user state and active sessions
+  - suspending/reactivating accounts
+  - revoking sessions
+  - resetting planner state
+  - seeding demo planner data
+  - clearing planner activity (while keeping the account)
 
 ## Local Data
 

--- a/server/createApp.js
+++ b/server/createApp.js
@@ -206,12 +206,89 @@ export function createApp({
   }
 
   function authResponseForUser(user, settingsJson = user.settings_json) {
+    const adminCount = Number(
+      db.prepare("SELECT COUNT(*) AS count FROM users WHERE role = 'admin'").get()?.count ?? 0
+    );
     return {
       user: publicUser(user),
       settings: parseStoredSettings(settingsJson),
       featureFlags: getFeatureFlags(),
       auth: getAuthConfig(),
+      adminBootstrapEligible:
+        getAuthConfig().mode === 'local' &&
+        user.role !== 'admin' &&
+        adminCount === 0,
     };
+  }
+
+  function clearPlannerActivity(settingsJson) {
+    const current = parseStoredSettings(settingsJson);
+    return normalizeState({
+      ...current,
+      phases: current.phases.map((phase) => ({
+        ...phase,
+        tasks: phase.tasks
+          .filter((task) => task.type !== 'oneoff')
+          .map((task) => ({ ...task, done: false, carryCount: 0 })),
+      })),
+      healthState: 'steady',
+      preferences: {
+        ...(current.preferences ?? {}),
+        lastResetDate: null,
+      },
+    });
+  }
+
+  function seedDemoPlannerState(settingsJson) {
+    const current = parseStoredSettings(settingsJson);
+    const dateKey = new Date().toISOString().slice(0, 10);
+    const nextPhases = current.phases.map((phase, phaseIndex) => ({
+      ...phase,
+      tasks: phase.tasks.map((task, taskIndex) => ({
+        ...task,
+        done: phaseIndex === 0 ? taskIndex <= 1 : phaseIndex === 1 ? taskIndex === 0 : false,
+        carryCount: phaseIndex >= 2 && taskIndex === 0 ? 1 : 0,
+      })),
+    }));
+
+    if (nextPhases[0]) {
+      nextPhases[0].tasks.push({
+        id: `task-${crypto.randomUUID()}`,
+        title: 'Inbox sweep (demo)',
+        done: false,
+        minutes: 12,
+        type: 'oneoff',
+        carryCount: 0,
+      });
+    }
+    if (nextPhases[1]) {
+      nextPhases[1].tasks.push({
+        id: `task-${crypto.randomUUID()}`,
+        title: 'Follow-up email block (demo)',
+        done: false,
+        minutes: 18,
+        type: 'oneoff',
+        carryCount: 0,
+      });
+    }
+
+    return normalizeState({
+      ...current,
+      phases: nextPhases,
+      activePhaseId: nextPhases[1]?.id ?? nextPhases[0]?.id ?? current.activePhaseId,
+      healthState: 'scattered',
+      routineType: 'session',
+      preferences: {
+        ...(current.preferences ?? {}),
+        setupComplete: true,
+        onboardingComplete: true,
+        goals:
+          Array.isArray(current.preferences?.goals) && current.preferences.goals.length > 0
+            ? current.preferences.goals
+            : ['writing', 'health'],
+        lastResetDate: dateKey,
+      },
+    });
   }
 
   function writeAuditEvent({
@@ -352,6 +429,38 @@ export function createApp({
 
   app.get('/api/auth/config', (_req, res) => {
     res.json({ auth: getAuthConfig() });
+  });
+
+  app.post('/api/auth/claim-admin', requireAuth, (req, res) => {
+    if (getAuthConfig().mode !== 'local') {
+      return res.status(403).json({ error: 'Admin bootstrap is disabled for managed auth mode.' });
+    }
+
+    const adminCount = Number(
+      db.prepare("SELECT COUNT(*) AS count FROM users WHERE role = 'admin'").get()?.count ?? 0
+    );
+    if (adminCount > 0 && req.user.role !== 'admin') {
+      return res.status(403).json({ error: 'An admin account already exists. Ask an admin for access.' });
+    }
+
+    if (req.user.role !== 'admin') {
+      db.prepare("UPDATE users SET role = 'admin' WHERE id = ?").run(req.user.id);
+      req.user.role = 'admin';
+      writeAuditEvent({
+        eventType: 'auth.admin_bootstrap_claimed',
+        level: 'warn',
+        actorUserId: req.user.id,
+        requestId: req.requestId,
+        message: `Admin bootstrap claimed by ${req.user.email}`,
+      });
+    }
+
+    const user = db
+      .prepare(
+        'SELECT id, email, display_name, role, auth_provider, auth_subject, account_status, settings_json FROM users WHERE id = ?'
+      )
+      .get(req.user.id);
+    return res.json(authResponseForUser(user));
   });
 
   app.post('/api/auth/register', (req, res) => {
@@ -671,6 +780,64 @@ export function createApp({
     res.json({
       ok: true,
       user: publicUser(target),
+    });
+  });
+
+  app.post('/api/admin/users/:userId/seed-demo', requireAuth, requireAdmin, (req, res) => {
+    const targetUserId = String(req.params.userId ?? '').trim();
+    const target = db
+      .prepare('SELECT id, email, display_name, role, auth_provider, account_status, settings_json FROM users WHERE id = ?')
+      .get(targetUserId);
+    if (!target) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    const seededState = seedDemoPlannerState(target.settings_json);
+    db.prepare('UPDATE users SET settings_json = ? WHERE id = ?')
+      .run(JSON.stringify(seededState), targetUserId);
+
+    writeAuditEvent({
+      eventType: 'admin.user_seeded_demo',
+      level: 'warn',
+      actorUserId: req.user.id,
+      targetUserId,
+      requestId: req.requestId,
+      message: `Demo planner state seeded by admin: ${target.email}`,
+    });
+
+    return res.json({
+      ok: true,
+      user: publicUser(target),
+      plannerStateSummary: plannerStateSummaryForSettings(JSON.stringify(seededState)),
+    });
+  });
+
+  app.post('/api/admin/users/:userId/clear-activity', requireAuth, requireAdmin, (req, res) => {
+    const targetUserId = String(req.params.userId ?? '').trim();
+    const target = db
+      .prepare('SELECT id, email, display_name, role, auth_provider, account_status, settings_json FROM users WHERE id = ?')
+      .get(targetUserId);
+    if (!target) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    const clearedState = clearPlannerActivity(target.settings_json);
+    db.prepare('UPDATE users SET settings_json = ? WHERE id = ?')
+      .run(JSON.stringify(clearedState), targetUserId);
+
+    writeAuditEvent({
+      eventType: 'admin.user_activity_cleared',
+      level: 'warn',
+      actorUserId: req.user.id,
+      targetUserId,
+      requestId: req.requestId,
+      message: `Planner activity cleared by admin: ${target.email}`,
+    });
+
+    return res.json({
+      ok: true,
+      user: publicUser(target),
+      plannerStateSummary: plannerStateSummaryForSettings(JSON.stringify(clearedState)),
     });
   });
 

--- a/server/createApp.js
+++ b/server/createApp.js
@@ -244,16 +244,18 @@ export function createApp({
     const dateKey = new Date().toISOString().slice(0, 10);
     const nextPhases = current.phases.map((phase, phaseIndex) => ({
       ...phase,
-      tasks: phase.tasks.map((task, taskIndex) => ({
-        ...task,
-        done: phaseIndex === 0 ? taskIndex <= 1 : phaseIndex === 1 ? taskIndex === 0 : false,
-        carryCount: phaseIndex >= 2 && taskIndex === 0 ? 1 : 0,
-      })),
+      tasks: phase.tasks
+        .filter((task) => task.type === 'template')
+        .map((task, taskIndex) => ({
+          ...task,
+          done: phaseIndex === 0 ? taskIndex <= 1 : phaseIndex === 1 ? taskIndex === 0 : false,
+          carryCount: phaseIndex >= 2 && taskIndex === 0 ? 1 : 0,
+        })),
     }));
 
     if (nextPhases[0]) {
       nextPhases[0].tasks.push({
-        id: `task-${crypto.randomUUID()}`,
+        id: 'demo-task-inbox-sweep',
         title: 'Inbox sweep (demo)',
         done: false,
         minutes: 12,
@@ -263,7 +265,7 @@ export function createApp({
     }
     if (nextPhases[1]) {
       nextPhases[1].tasks.push({
-        id: `task-${crypto.randomUUID()}`,
+        id: 'demo-task-followup-email',
         title: 'Follow-up email block (demo)',
         done: false,
         minutes: 18,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,6 +65,9 @@ export default function App() {
     authError,
     authForm,
     authConfig,
+    adminBootstrapEligible,
+    adminClaimPending,
+    adminClaimStatus,
     user,
     settings,
     setSettings,
@@ -72,6 +75,7 @@ export default function App() {
     setFeatureFlags,
     loadedSettingsRef,
     handleAuthSubmit,
+    claimAdminAccess,
     handleLogout,
     updateAuthForm,
   } = useAuthSession({
@@ -95,6 +99,8 @@ export default function App() {
     inspectUser,
     setUserAccountStatus,
     revokeUserSessions,
+    seedDemoState,
+    clearUserActivity,
   } = useAdminData({
     user,
     siteView,
@@ -716,6 +722,11 @@ export default function App() {
             setSiteView={setSiteView}
             setSettings={setSettings}
             isCycleTrackingEnabled={isFeatureEnabled('cycle_tracking')}
+            authConfig={authConfig}
+            adminBootstrapEligible={adminBootstrapEligible}
+            adminClaimPending={adminClaimPending}
+            adminClaimStatus={adminClaimStatus}
+            claimAdminAccess={claimAdminAccess}
           />
         )}
 
@@ -737,6 +748,8 @@ export default function App() {
             inspectUser={inspectUser}
             setUserAccountStatus={setUserAccountStatus}
             revokeUserSessions={revokeUserSessions}
+            seedDemoState={seedDemoState}
+            clearUserActivity={clearUserActivity}
           />
         )}
 

--- a/src/hooks/useAdminData.js
+++ b/src/hooks/useAdminData.js
@@ -145,6 +145,44 @@ export function useAdminData({ user, siteView, onFeatureFlagsChange }) {
     }
   }
 
+  async function seedDemoState(targetUserId) {
+    setAdminStatus('');
+    setAdminLoading(true);
+    try {
+      await api(`/api/admin/users/${encodeURIComponent(targetUserId)}/seed-demo`, {
+        method: 'POST',
+      });
+      setAdminStatus('Seeded demo planner state.');
+      await Promise.all([refreshAdminSummary(), searchAdminUsers()]);
+      if (selectedAdminUser?.user?.id === targetUserId) {
+        await inspectUser(targetUserId);
+      }
+    } catch (error) {
+      setAdminStatus(error.message);
+    } finally {
+      setAdminLoading(false);
+    }
+  }
+
+  async function clearUserActivity(targetUserId) {
+    setAdminStatus('');
+    setAdminLoading(true);
+    try {
+      await api(`/api/admin/users/${encodeURIComponent(targetUserId)}/clear-activity`, {
+        method: 'POST',
+      });
+      setAdminStatus('Cleared planner activity.');
+      await Promise.all([refreshAdminSummary(), searchAdminUsers()]);
+      if (selectedAdminUser?.user?.id === targetUserId) {
+        await inspectUser(targetUserId);
+      }
+    } catch (error) {
+      setAdminStatus(error.message);
+    } finally {
+      setAdminLoading(false);
+    }
+  }
+
   useEffect(() => {
     if (siteView === 'admin' && user?.role === 'admin') {
       refreshAdminSummary();
@@ -168,5 +206,7 @@ export function useAdminData({ user, siteView, onFeatureFlagsChange }) {
     inspectUser,
     setUserAccountStatus,
     revokeUserSessions,
+    seedDemoState,
+    clearUserActivity,
   };
 }

--- a/src/hooks/useAuthSession.js
+++ b/src/hooks/useAuthSession.js
@@ -22,6 +22,9 @@ export function useAuthSession({ onAuthenticated, onSignedOut } = {}) {
   const [authError, setAuthError] = useState('');
   const [authForm, setAuthForm] = useState(DEFAULT_AUTH_FORM);
   const [authConfig, setAuthConfig] = useState(DEFAULT_AUTH_CONFIG);
+  const [adminBootstrapEligible, setAdminBootstrapEligible] = useState(false);
+  const [adminClaimPending, setAdminClaimPending] = useState(false);
+  const [adminClaimStatus, setAdminClaimStatus] = useState('');
   const [user, setUser] = useState(null);
   const [settings, setSettings] = useState(DEFAULT_SETTINGS);
   const [featureFlags, setFeatureFlags] = useState(DEFAULT_FEATURE_FLAGS);
@@ -36,6 +39,17 @@ export function useAuthSession({ onAuthenticated, onSignedOut } = {}) {
   useEffect(() => {
     onSignedOutRef.current = onSignedOut;
   }, [onSignedOut]);
+
+  function applyAuthenticatedPayload(data, fallbackAuth = DEFAULT_AUTH_CONFIG) {
+    setUser(data.user);
+    setSettings(data.settings);
+    setFeatureFlags(data.featureFlags ?? DEFAULT_FEATURE_FLAGS);
+    setAuthConfig(data.auth ?? fallbackAuth);
+    setAdminBootstrapEligible(Boolean(data.adminBootstrapEligible));
+    loadedSettingsRef.current = true;
+    setAuthChecked(true);
+    onAuthenticatedRef.current?.(data);
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -54,12 +68,7 @@ export function useAuthSession({ onAuthenticated, onSignedOut } = {}) {
         if (cancelled) {
           return;
         }
-        setUser(data.user);
-        setSettings(data.settings);
-        setFeatureFlags(data.featureFlags ?? DEFAULT_FEATURE_FLAGS);
-        setAuthConfig(data.auth ?? authMeta);
-        loadedSettingsRef.current = true;
-        onAuthenticatedRef.current?.(data);
+        applyAuthenticatedPayload(data, authMeta);
       } catch {
         if (!cancelled) {
           loadedSettingsRef.current = false;
@@ -91,18 +100,30 @@ export function useAuthSession({ onAuthenticated, onSignedOut } = {}) {
         method: 'POST',
         body: JSON.stringify(authForm),
       });
-      setUser(data.user);
-      setSettings(data.settings);
-      setFeatureFlags(data.featureFlags ?? DEFAULT_FEATURE_FLAGS);
-      setAuthConfig(data.auth ?? DEFAULT_AUTH_CONFIG);
-      loadedSettingsRef.current = true;
-      setAuthChecked(true);
+      applyAuthenticatedPayload(data);
       setAuthForm(DEFAULT_AUTH_FORM);
-      onAuthenticatedRef.current?.(data);
     } catch (error) {
       setAuthError(error.message);
     } finally {
       setAuthPending(false);
+    }
+  }
+
+  async function claimAdminAccess() {
+    setAdminClaimPending(true);
+    setAdminClaimStatus('');
+    try {
+      const data = await api('/api/auth/claim-admin', {
+        method: 'POST',
+      });
+      applyAuthenticatedPayload(data);
+      setAdminClaimStatus('Admin access enabled for this account.');
+      return true;
+    } catch (error) {
+      setAdminClaimStatus(error.message);
+      return false;
+    } finally {
+      setAdminClaimPending(false);
     }
   }
 
@@ -116,6 +137,9 @@ export function useAuthSession({ onAuthenticated, onSignedOut } = {}) {
     setUser(null);
     setSettings(DEFAULT_SETTINGS);
     setFeatureFlags(DEFAULT_FEATURE_FLAGS);
+    setAdminBootstrapEligible(false);
+    setAdminClaimPending(false);
+    setAdminClaimStatus('');
     setAuthMode('login');
     setAuthError('');
     onSignedOutRef.current?.();
@@ -136,6 +160,9 @@ export function useAuthSession({ onAuthenticated, onSignedOut } = {}) {
     authError,
     authForm,
     authConfig,
+    adminBootstrapEligible,
+    adminClaimPending,
+    adminClaimStatus,
     user,
     settings,
     setSettings,
@@ -143,6 +170,7 @@ export function useAuthSession({ onAuthenticated, onSignedOut } = {}) {
     setFeatureFlags,
     loadedSettingsRef,
     handleAuthSubmit,
+    claimAdminAccess,
     handleLogout,
     updateAuthForm,
   };

--- a/src/views/AdminView.jsx
+++ b/src/views/AdminView.jsx
@@ -15,6 +15,8 @@ export function AdminView({
   inspectUser,
   setUserAccountStatus,
   revokeUserSessions,
+  seedDemoState,
+  clearUserActivity,
 }) {
   function confirmAndRun(message, action) {
     if (!window.confirm(message)) {
@@ -164,6 +166,28 @@ export function AdminView({
                   }
                 >
                   {adminUser.id === user.id ? 'Current user' : 'Reset state'}
+                </button>
+                <button
+                  className="ghost small"
+                  onClick={() =>
+                    confirmAndRun(
+                      `Seed demo planner data for ${adminUser.email}?`,
+                      () => seedDemoState(adminUser.id)
+                    )
+                  }
+                >
+                  Seed demo
+                </button>
+                <button
+                  className="ghost small"
+                  onClick={() =>
+                    confirmAndRun(
+                      `Clear planner activity for ${adminUser.email}? One-off tasks and completion state will be removed.`,
+                      () => clearUserActivity(adminUser.id)
+                    )
+                  }
+                >
+                  Clear activity
                 </button>
               </div>
             </div>

--- a/src/views/ProfileView.jsx
+++ b/src/views/ProfileView.jsx
@@ -8,6 +8,11 @@ export function ProfileView({
   setSiteView,
   setSettings,
   isCycleTrackingEnabled,
+  authConfig,
+  adminBootstrapEligible,
+  adminClaimPending,
+  adminClaimStatus,
+  claimAdminAccess,
 }) {
   return (
     <section className="card">
@@ -84,6 +89,27 @@ export function ProfileView({
               )}
             </div>
           )}
+        </div>
+      )}
+
+      {user.role !== 'admin' && authConfig?.mode === 'local' && (
+        <div style={{ marginTop: '1rem' }}>
+          <p className="card-label">Admin access</p>
+          <p className="muted-copy">
+            {adminBootstrapEligible
+              ? 'No admin account exists yet. You can claim admin access for local testing.'
+              : 'An admin account already exists for this environment.'}
+          </p>
+          <div className="button-row" style={{ marginTop: '0.45rem' }}>
+            <button
+              className="ghost"
+              disabled={!adminBootstrapEligible || adminClaimPending}
+              onClick={claimAdminAccess}
+            >
+              {adminClaimPending ? 'Claiming admin access...' : 'Claim admin access'}
+            </button>
+          </div>
+          {adminClaimStatus && <p className="status-message">{adminClaimStatus}</p>}
         </div>
       )}
 

--- a/test/api-routes.test.js
+++ b/test/api-routes.test.js
@@ -422,6 +422,24 @@ test('admin can seed demo state and clear user activity', async () => {
     );
     assert.ok(seededOneOffCount > 0);
 
+    const seededAgain = await server.request(`/api/admin/users/${userId}/seed-demo`, {
+      method: 'POST',
+      headers: { cookie: adminCookie },
+    });
+    assert.equal(seededAgain.response.status, 200);
+    assert.equal(seededAgain.body.ok, true);
+    assert.equal(seededAgain.body.plannerStateSummary.totalTasks, seeded.body.plannerStateSummary.totalTasks);
+
+    const reseededSettingsRow = server.db
+      .prepare('SELECT settings_json FROM users WHERE id = ?')
+      .get(userId);
+    const reseededSettings = JSON.parse(reseededSettingsRow.settings_json);
+    const reseededOneOffCount = reseededSettings.phases.reduce(
+      (sum, phase) => sum + phase.tasks.filter((task) => task.type === 'oneoff').length,
+      0
+    );
+    assert.equal(reseededOneOffCount, seededOneOffCount);
+
     const cleared = await server.request(`/api/admin/users/${userId}/clear-activity`, {
       method: 'POST',
       headers: { cookie: adminCookie },

--- a/test/api-routes.test.js
+++ b/test/api-routes.test.js
@@ -324,3 +324,127 @@ test('admin can inspect users and revoke sessions while preserving current admin
     await server.close();
   }
 });
+
+test('first local user can claim admin when no admin exists', async () => {
+  const server = await startTestServer({ name: 'focusflow-claim-admin' });
+  try {
+    const registration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Taylor',
+        email: 'taylor@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const cookie = readCookie(registration.response.headers.get('set-cookie'));
+    assert.equal(registration.body.user.role, 'user');
+    assert.equal(registration.body.adminBootstrapEligible, true);
+
+    const claimed = await server.request('/api/auth/claim-admin', {
+      method: 'POST',
+      headers: { cookie },
+    });
+    assert.equal(claimed.response.status, 200);
+    assert.equal(claimed.body.user.role, 'admin');
+    assert.equal(claimed.body.adminBootstrapEligible, false);
+
+    const secondUser = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Jordan',
+        email: 'jordan@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const secondCookie = readCookie(secondUser.response.headers.get('set-cookie'));
+    const denied = await server.request('/api/auth/claim-admin', {
+      method: 'POST',
+      headers: { cookie: secondCookie },
+    });
+    assert.equal(denied.response.status, 403);
+  } finally {
+    await server.close();
+  }
+});
+
+test('admin can seed demo state and clear user activity', async () => {
+  const server = await startTestServer({
+    name: 'focusflow-seed-and-clear',
+    adminEmails: ['admin@example.com'],
+  });
+  try {
+    const adminRegistration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Admin',
+        email: 'admin@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const adminCookie = readCookie(adminRegistration.response.headers.get('set-cookie'));
+
+    const userRegistration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Jordan',
+        email: 'jordan@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const userId = userRegistration.body.user.id;
+
+    const seeded = await server.request(`/api/admin/users/${userId}/seed-demo`, {
+      method: 'POST',
+      headers: { cookie: adminCookie },
+    });
+    assert.equal(seeded.response.status, 200);
+    assert.equal(seeded.body.ok, true);
+    assert.equal(seeded.body.plannerStateSummary.setupComplete, true);
+    assert.equal(seeded.body.plannerStateSummary.onboardingComplete, true);
+    assert.ok(seeded.body.plannerStateSummary.totalTasks > 0);
+
+    const seededInspect = await server.request(`/api/admin/users/${userId}`, {
+      headers: { cookie: adminCookie },
+    });
+    assert.equal(seededInspect.response.status, 200);
+    assert.equal(seededInspect.body.plannerStateSummary.completedTasks > 0, true);
+    const seededSettingsRow = server.db
+      .prepare('SELECT settings_json FROM users WHERE id = ?')
+      .get(userId);
+    const seededSettings = JSON.parse(seededSettingsRow.settings_json);
+    const seededOneOffCount = seededSettings.phases.reduce(
+      (sum, phase) => sum + phase.tasks.filter((task) => task.type === 'oneoff').length,
+      0
+    );
+    assert.ok(seededOneOffCount > 0);
+
+    const cleared = await server.request(`/api/admin/users/${userId}/clear-activity`, {
+      method: 'POST',
+      headers: { cookie: adminCookie },
+    });
+    assert.equal(cleared.response.status, 200);
+    assert.equal(cleared.body.ok, true);
+    assert.equal(cleared.body.plannerStateSummary.completedTasks, 0);
+
+    const clearedInspect = await server.request(`/api/admin/users/${userId}`, {
+      headers: { cookie: adminCookie },
+    });
+    assert.equal(clearedInspect.response.status, 200);
+    assert.equal(clearedInspect.body.plannerStateSummary.completedTasks, 0);
+    const clearedSettingsRow = server.db
+      .prepare('SELECT settings_json FROM users WHERE id = ?')
+      .get(userId);
+    const clearedSettings = JSON.parse(clearedSettingsRow.settings_json);
+    const clearedOneOffCount = clearedSettings.phases.reduce(
+      (sum, phase) => sum + phase.tasks.filter((task) => task.type === 'oneoff').length,
+      0
+    );
+    assert.equal(clearedOneOffCount, 0);
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add local-auth admin bootstrap so a signed-in user can claim admin when no admin exists yet
- add admin testing utilities to seed demo planner state and clear planner activity without deleting accounts
- surface bootstrap access in Profile and add new testing actions in Admin UI
- extend API tests for claim-admin and testing utility endpoints
- update README and MEMORY artifacts to document the new flows

## Testing
- npm test
- npm run build
- node --check server/createApp.js
- node --check src/hooks/useAuthSession.js
- node --check src/hooks/useAdminData.js