### PR TITLE
Issue 18: Task action details with day vs template scope

### DIFF
--- a/server/defaultState.js
+++ b/server/defaultState.js
@@ -106,6 +106,7 @@ export function normalizeState(input) {
                     Number.isFinite(Number(task.carryCount)) && Number(task.carryCount) >= 0
                       ? Number(task.carryCount)
                       : 0,
+                  details: typeof task.details === 'string' ? task.details.trim() : '',
                 }))
             : [],
         }))

--- a/server/defaultState.js
+++ b/server/defaultState.js
@@ -2,6 +2,13 @@ import crypto from 'node:crypto';
 
 export const HEALTH_OPTIONS = ['steady', 'scattered', 'drained'];
 
+function inferTaskCategory(title) {
+  const normalized = String(title ?? '').toLowerCase();
+  return /(exercise|workout|walk|run|movement|stretch|rehab|yoga|bike|swim)/.test(normalized)
+    ? 'exercise'
+    : 'general';
+}
+
 export function buildDefaultState() {
   return {
     phases: [
@@ -107,6 +114,10 @@ export function normalizeState(input) {
                       ? Number(task.carryCount)
                       : 0,
                   details: typeof task.details === 'string' ? task.details.trim() : '',
+                  category:
+                    task.category === 'exercise'
+                      ? 'exercise'
+                      : inferTaskCategory(task.title),
                 }))
             : [],
         }))

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import {
   getProactiveTask,
   getSuggestions,
   greetingFor,
+  inferTaskCategory,
   storageKeyForUser,
   circadianWindow,
 } from './lib/focusFlowCore.js';
@@ -44,6 +45,7 @@ export default function App() {
   const [editTitle, setEditTitle] = useState('');
   const [editMinutes, setEditMinutes] = useState('');
   const [editDetails, setEditDetails] = useState('');
+  const [editCategory, setEditCategory] = useState('general');
   const [applyDetailsToMatchingTemplates, setApplyDetailsToMatchingTemplates] = useState(false);
   const [setupDraft, setSetupDraft] = useState({});
   const [routineOverridden, setRoutineOverridden] = useState(false);
@@ -383,6 +385,14 @@ export default function App() {
     setQuickAddInputs((current) => ({ ...current, [phaseId]: '' }));
   }
 
+  function addExerciseTaskToPhase(phaseId, title, minutes = 20) {
+    if (!title.trim()) return;
+    updateTasksInPhase(phaseId, (tasks) => [
+      ...tasks,
+      createTask(title.trim(), minutes, 'oneoff', '', 'exercise'),
+    ]);
+  }
+
   function addSuggestionTask(phaseId, suggestion) {
     updateTasksInPhase(phaseId, (tasks) => [
       ...tasks,
@@ -393,6 +403,39 @@ export default function App() {
   function addTemplateTaskToPhase(phaseId, title) {
     if (!title.trim()) return;
     updateTasksInPhase(phaseId, (tasks) => [...tasks, createTask(title.trim(), null, 'template')]);
+  }
+
+  function moveTaskToPhase(fromPhaseId, taskId, targetPhaseId) {
+    if (fromPhaseId === targetPhaseId) return;
+    setSettings((current) => {
+      let movedTask = null;
+      const removed = current.phases.map((phase) => {
+        if (phase.id !== fromPhaseId) return phase;
+        return {
+          ...phase,
+          tasks: (phase.tasks ?? []).filter((task) => {
+            if (task.id === taskId) {
+              movedTask = task;
+              return false;
+            }
+            return true;
+          }),
+        };
+      });
+
+      if (!movedTask) {
+        return current;
+      }
+
+      return {
+        ...current,
+        phases: removed.map((phase) =>
+          phase.id === targetPhaseId
+            ? { ...phase, tasks: [...(phase.tasks ?? []), movedTask] }
+            : phase
+        ),
+      };
+    });
   }
 
   function updateTaskDetailsInPhase(phaseId, taskId, details) {
@@ -426,6 +469,7 @@ export default function App() {
     setEditTitle(task.title);
     setEditMinutes(task.minutes != null ? String(task.minutes) : '');
     setEditDetails(task.details ?? '');
+    setEditCategory(task.category ?? inferTaskCategory(task.title));
     setApplyDetailsToMatchingTemplates(false);
   }
 
@@ -451,6 +495,7 @@ export default function App() {
                 title,
                 minutes: Number.isFinite(parsedMinutes) && parsedMinutes > 0 ? parsedMinutes : null,
                 details: normalizedDetails,
+                category: editCategory === 'exercise' ? 'exercise' : 'general',
               };
             }
             if (
@@ -466,11 +511,13 @@ export default function App() {
       };
     });
     setEditingTaskId(null);
+    setEditCategory('general');
     setApplyDetailsToMatchingTemplates(false);
   }
 
   function cancelEditTask() {
     setEditingTaskId(null);
+    setEditCategory('general');
     setApplyDetailsToMatchingTemplates(false);
   }
 
@@ -852,6 +899,7 @@ export default function App() {
             editTitle={editTitle}
             editMinutes={editMinutes}
             editDetails={editDetails}
+            editCategory={editCategory}
             applyDetailsToMatchingTemplates={applyDetailsToMatchingTemplates}
             collapsedPhases={collapsedPhases}
             quickAddInputs={quickAddInputs}
@@ -879,6 +927,7 @@ export default function App() {
             setEditTitle={setEditTitle}
             setEditMinutes={setEditMinutes}
             setEditDetails={setEditDetails}
+            setEditCategory={setEditCategory}
             setApplyDetailsToMatchingTemplates={setApplyDetailsToMatchingTemplates}
             togglePhaseCollapsed={togglePhaseCollapsed}
             handleStartPhase={handleStartPhase}
@@ -892,6 +941,8 @@ export default function App() {
             cancelEditTask={cancelEditTask}
             deleteTask={deleteTask}
             addTaskToPhase={addTaskToPhase}
+            addExerciseTaskToPhase={addExerciseTaskToPhase}
+            moveTaskToPhase={moveTaskToPhase}
             addSuggestionTask={addSuggestionTask}
             suggestNextAction={suggestNextAction}
             handleSkipCheckin={handleSkipCheckin}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -479,10 +479,8 @@ export default function App() {
     const parsedMinutes = Number(editMinutes);
     const normalizedDetails = String(editDetails ?? '').trim();
     setSettings((current) => {
-      const targetTask = current.phases
-        .flatMap((phase) => phase.tasks ?? [])
-        .find((task) => task.id === taskId);
-      const matchingTitle = String(targetTask?.title ?? title).trim().toLowerCase();
+      // Match propagation by the edited title so rename + apply behaves predictably.
+      const matchingTitle = String(title).trim().toLowerCase();
 
       return {
         ...current,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,8 @@ export default function App() {
   const [editingTaskId, setEditingTaskId] = useState(null);
   const [editTitle, setEditTitle] = useState('');
   const [editMinutes, setEditMinutes] = useState('');
+  const [editDetails, setEditDetails] = useState('');
+  const [applyDetailsToMatchingTemplates, setApplyDetailsToMatchingTemplates] = useState(false);
   const [setupDraft, setSetupDraft] = useState({});
   const [routineOverridden, setRoutineOverridden] = useState(false);
   const [templateAddInputs, setTemplateAddInputs] = useState({});
@@ -393,28 +395,83 @@ export default function App() {
     updateTasksInPhase(phaseId, (tasks) => [...tasks, createTask(title.trim(), null, 'template')]);
   }
 
+  function updateTaskDetailsInPhase(phaseId, taskId, details) {
+    const normalizedDetails = String(details ?? '').trim();
+    updateTasksInPhase(phaseId, (tasks) =>
+      tasks.map((task) => (task.id === taskId ? { ...task, details: normalizedDetails } : task))
+    );
+  }
+
+  function applyTaskDetailsToMatchingTemplates(title, details) {
+    const normalizedTitle = String(title ?? '').trim().toLowerCase();
+    const normalizedDetails = String(details ?? '').trim();
+    if (!normalizedTitle) {
+      return;
+    }
+    setSettings((current) => ({
+      ...current,
+      phases: current.phases.map((phase) => ({
+        ...phase,
+        tasks: (phase.tasks ?? []).map((task) =>
+          task.type === 'template' && String(task.title ?? '').trim().toLowerCase() === normalizedTitle
+            ? { ...task, details: normalizedDetails }
+            : task
+        ),
+      })),
+    }));
+  }
+
   function startEditTask(task) {
     setEditingTaskId(task.id);
     setEditTitle(task.title);
     setEditMinutes(task.minutes != null ? String(task.minutes) : '');
+    setEditDetails(task.details ?? '');
+    setApplyDetailsToMatchingTemplates(false);
   }
 
   function saveEditTask(phaseId, taskId) {
     const title = editTitle.trim();
     if (!title) return;
     const parsedMinutes = Number(editMinutes);
-    updateTasksInPhase(phaseId, (tasks) =>
-      tasks.map((t) =>
-        t.id === taskId
-          ? { ...t, title, minutes: Number.isFinite(parsedMinutes) && parsedMinutes > 0 ? parsedMinutes : null }
-          : t
-      )
-    );
+    const normalizedDetails = String(editDetails ?? '').trim();
+    setSettings((current) => {
+      const targetTask = current.phases
+        .flatMap((phase) => phase.tasks ?? [])
+        .find((task) => task.id === taskId);
+      const matchingTitle = String(targetTask?.title ?? title).trim().toLowerCase();
+
+      return {
+        ...current,
+        phases: current.phases.map((phase) => ({
+          ...phase,
+          tasks: (phase.tasks ?? []).map((task) => {
+            if (task.id === taskId) {
+              return {
+                ...task,
+                title,
+                minutes: Number.isFinite(parsedMinutes) && parsedMinutes > 0 ? parsedMinutes : null,
+                details: normalizedDetails,
+              };
+            }
+            if (
+              applyDetailsToMatchingTemplates &&
+              task.type === 'template' &&
+              String(task.title ?? '').trim().toLowerCase() === matchingTitle
+            ) {
+              return { ...task, details: normalizedDetails };
+            }
+            return task;
+          }),
+        })),
+      };
+    });
     setEditingTaskId(null);
+    setApplyDetailsToMatchingTemplates(false);
   }
 
   function cancelEditTask() {
     setEditingTaskId(null);
+    setApplyDetailsToMatchingTemplates(false);
   }
 
   function deleteTask(phaseId, taskId) {
@@ -766,6 +823,8 @@ export default function App() {
             deleteTask={deleteTask}
             addTemplateTaskToPhase={addTemplateTaskToPhase}
             insertPhaseAt={insertPhaseAt}
+            updateTaskDetailsInPhase={updateTaskDetailsInPhase}
+            applyTaskDetailsToMatchingTemplates={applyTaskDetailsToMatchingTemplates}
           />
         )}
 
@@ -792,6 +851,8 @@ export default function App() {
             editingTaskId={editingTaskId}
             editTitle={editTitle}
             editMinutes={editMinutes}
+            editDetails={editDetails}
+            applyDetailsToMatchingTemplates={applyDetailsToMatchingTemplates}
             collapsedPhases={collapsedPhases}
             quickAddInputs={quickAddInputs}
             checkInDone={checkInDone}
@@ -817,6 +878,8 @@ export default function App() {
             setQuickAddInputs={setQuickAddInputs}
             setEditTitle={setEditTitle}
             setEditMinutes={setEditMinutes}
+            setEditDetails={setEditDetails}
+            setApplyDetailsToMatchingTemplates={setApplyDetailsToMatchingTemplates}
             togglePhaseCollapsed={togglePhaseCollapsed}
             handleStartPhase={handleStartPhase}
             handlePausePhase={handlePausePhase}

--- a/src/lib/focusFlowCore.js
+++ b/src/lib/focusFlowCore.js
@@ -11,7 +11,14 @@ export function formatSeconds(totalSeconds) {
   return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
 }
 
-export function createTask(title, minutes = null, type = 'oneoff', details = '') {
+export function inferTaskCategory(title) {
+  const normalized = String(title ?? '').toLowerCase();
+  return /(exercise|workout|walk|run|movement|stretch|rehab|yoga|bike|swim)/.test(normalized)
+    ? 'exercise'
+    : 'general';
+}
+
+export function createTask(title, minutes = null, type = 'oneoff', details = '', category = null) {
   const uuid = typeof crypto?.randomUUID === 'function'
     ? crypto.randomUUID()
     : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -23,6 +30,7 @@ export function createTask(title, minutes = null, type = 'oneoff', details = '')
     type,
     carryCount: 0,
     details: typeof details === 'string' ? details.trim() : '',
+    category: category === 'exercise' ? 'exercise' : inferTaskCategory(title),
   };
 }
 
@@ -411,6 +419,7 @@ export function getActiveProfile(hoursAwake, healthState, cycleInfo) {
 function inferTaskTypes(task) {
   const t = task.title.toLowerCase();
   const types = new Set();
+  if (task.category === 'exercise') types.add('movement');
   if (/writ|draft|creat|essay|chapter|blog|post|story|compost/.test(t)) types.add('creative');
   if (/spanish|french|german|japanese|language|vocab|grammar/.test(t)) types.add('study');
   if (/read|study|research|annotate|craft|input|primer/.test(t)) types.add('study');

--- a/src/lib/focusFlowCore.js
+++ b/src/lib/focusFlowCore.js
@@ -11,7 +11,7 @@ export function formatSeconds(totalSeconds) {
   return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
 }
 
-export function createTask(title, minutes = null, type = 'oneoff') {
+export function createTask(title, minutes = null, type = 'oneoff', details = '') {
   const uuid = typeof crypto?.randomUUID === 'function'
     ? crypto.randomUUID()
     : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -22,6 +22,7 @@ export function createTask(title, minutes = null, type = 'oneoff') {
     minutes,
     type,
     carryCount: 0,
+    details: typeof details === 'string' ? details.trim() : '',
   };
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -728,6 +728,21 @@ h3 {
   width: 6rem;
 }
 
+.task-edit-form .task-details-input {
+  width: 100%;
+  min-height: 5.5rem;
+  resize: vertical;
+}
+
+.task-edit-scope {
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
 .danger-text {
   color: var(--danger);
 }
@@ -788,6 +803,23 @@ h3 {
 .task-duration {
   font-size: 0.76rem;
   color: var(--muted);
+}
+
+.task-details {
+  margin-top: 0.3rem;
+}
+
+.task-details-toggle {
+  padding-left: 0;
+}
+
+.task-detail-list {
+  margin: 0.35rem 0 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.2rem;
+  color: var(--muted);
+  font-size: 0.8rem;
 }
 
 .task-timer-running {
@@ -1543,13 +1575,18 @@ h3 {
 }
 
 .settings-template-task-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  display: grid;
+  gap: 0.45rem;
   padding: 0.35rem 0.5rem;
   border-radius: 8px;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--line);
+}
+
+.settings-template-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .settings-template-task-title {
@@ -1557,6 +1594,22 @@ h3 {
   font-size: 0.85rem;
   color: var(--ink);
   min-width: 0;
+}
+
+.settings-template-details-input {
+  width: 100%;
+  font-size: 0.82rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--line);
+  color: var(--ink);
+  resize: vertical;
+}
+
+.settings-template-details-input:focus {
+  outline: none;
+  border-color: rgba(90, 170, 200, 0.4);
 }
 
 .settings-template-add input {

--- a/src/styles.css
+++ b/src/styles.css
@@ -743,6 +743,18 @@ h3 {
   color: var(--muted);
 }
 
+.task-edit-category {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.task-edit-category select {
+  min-width: 7.5rem;
+}
+
 .danger-text {
   color: var(--danger);
 }
@@ -822,6 +834,17 @@ h3 {
   font-size: 0.8rem;
 }
 
+.task-category-badge {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 0.12rem 0.42rem;
+  border-radius: 999px;
+  background: rgba(107, 191, 191, 0.14);
+  border: 1px solid rgba(107, 191, 191, 0.35);
+  color: var(--secondary);
+}
+
 .task-timer-running {
   font-size: 0.82rem;
   font-weight: 700;
@@ -852,6 +875,42 @@ h3 {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.exercise-section {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.exercise-add-form {
+  display: grid;
+  grid-template-columns: minmax(10rem, 1fr) auto auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.exercise-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.exercise-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.55rem 0.65rem;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.exercise-row.done {
+  opacity: 0.55;
+}
+
+.exercise-row select {
+  min-width: 9rem;
 }
 
 /* Phase sections */
@@ -1843,6 +1902,19 @@ h3 {
 
   .phase-section-header {
     padding: 0.7rem 0.75rem;
+  }
+
+  .exercise-add-form {
+    grid-template-columns: 1fr;
+  }
+
+  .exercise-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .exercise-row select {
+    width: 100%;
   }
 }
 

--- a/src/views/PlannerView.jsx
+++ b/src/views/PlannerView.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   formatClockFromIso,
   formatDateLong,
@@ -28,6 +29,8 @@ export function PlannerView({
   editingTaskId,
   editTitle,
   editMinutes,
+  editDetails,
+  applyDetailsToMatchingTemplates,
   collapsedPhases,
   quickAddInputs,
   checkInDone,
@@ -53,6 +56,8 @@ export function PlannerView({
   setQuickAddInputs,
   setEditTitle,
   setEditMinutes,
+  setEditDetails,
+  setApplyDetailsToMatchingTemplates,
   togglePhaseCollapsed,
   handleStartPhase,
   handlePausePhase,
@@ -73,6 +78,20 @@ export function PlannerView({
   isFeatureEnabled,
   setRoutineOverridden,
 }) {
+  const [expandedTaskDetails, setExpandedTaskDetails] = useState(() => new Set());
+
+  function toggleTaskDetails(taskId) {
+    setExpandedTaskDetails((current) => {
+      const next = new Set(current);
+      if (next.has(taskId)) {
+        next.delete(taskId);
+      } else {
+        next.add(taskId);
+      }
+      return next;
+    });
+  }
+
   return (
     <>
       {isFeatureEnabled('mind_context') && (
@@ -139,7 +158,10 @@ export function PlannerView({
             editingTaskId={editingTaskId}
             editTitle={editTitle}
             editMinutes={editMinutes}
+            editDetails={editDetails}
+            applyDetailsToMatchingTemplates={applyDetailsToMatchingTemplates}
             collapsedPhases={collapsedPhases}
+            expandedTaskDetails={expandedTaskDetails}
             quickAddInputs={quickAddInputs}
             phaseRemaining={phaseRemaining}
             phaseRunning={phaseRunning}
@@ -149,6 +171,9 @@ export function PlannerView({
             setQuickAddInputs={setQuickAddInputs}
             setEditTitle={setEditTitle}
             setEditMinutes={setEditMinutes}
+            setEditDetails={setEditDetails}
+            setApplyDetailsToMatchingTemplates={setApplyDetailsToMatchingTemplates}
+            toggleTaskDetails={toggleTaskDetails}
             setSettingsPatch={setSettingsPatch}
             togglePhaseCollapsed={togglePhaseCollapsed}
             handleStartPhase={handleStartPhase}
@@ -431,7 +456,10 @@ function PhaseSection({
   editingTaskId,
   editTitle,
   editMinutes,
+  editDetails,
+  applyDetailsToMatchingTemplates,
   collapsedPhases,
+  expandedTaskDetails,
   quickAddInputs,
   phaseRemaining,
   phaseRunning,
@@ -441,6 +469,9 @@ function PhaseSection({
   setQuickAddInputs,
   setEditTitle,
   setEditMinutes,
+  setEditDetails,
+  setApplyDetailsToMatchingTemplates,
+  toggleTaskDetails,
   setSettingsPatch,
   togglePhaseCollapsed,
   handleStartPhase,
@@ -520,6 +551,11 @@ function PhaseSection({
               const timerRunning = timer?.running ?? false;
               const timerSeconds = timer?.seconds ?? 0;
               const isEditing = editingTaskId === task.id;
+              const detailsExpanded = expandedTaskDetails.has(task.id);
+              const detailLines = String(task.details ?? '')
+                .split('\n')
+                .map((line) => line.trim())
+                .filter(Boolean);
               const taskFit = getTaskFit(task, activeProfile);
 
               return (
@@ -536,6 +572,21 @@ function PhaseSection({
                         value={editMinutes}
                         onChange={(event) => setEditMinutes(event.target.value)}
                       />
+                      <textarea
+                        className="task-details-input"
+                        rows={4}
+                        placeholder="Task details/actions (one per line)"
+                        value={editDetails}
+                        onChange={(event) => setEditDetails(event.target.value)}
+                      />
+                      <label className="task-edit-scope">
+                        <input
+                          type="checkbox"
+                          checked={applyDetailsToMatchingTemplates}
+                          onChange={(event) => setApplyDetailsToMatchingTemplates(event.target.checked)}
+                        />
+                        Apply details to matching repeating tasks by name
+                      </label>
                       <button type="submit">Save</button>
                       <button type="button" className="ghost" onClick={cancelEditTask}>
                         Cancel
@@ -569,6 +620,26 @@ function PhaseSection({
                               {timerRunning ? formatSeconds(timerSeconds) : `${formatSeconds(timerSeconds)} left`}
                               {' · '}{task.minutes}m total
                             </span>
+                          )}
+                        </div>
+                        <div className="task-details">
+                          <button
+                            className="ghost small task-details-toggle"
+                            onClick={() => toggleTaskDetails(task.id)}
+                            type="button"
+                          >
+                            {detailsExpanded ? 'Hide actions' : `Show actions${detailLines.length > 0 ? ` (${detailLines.length})` : ''}`}
+                          </button>
+                          {detailsExpanded && (
+                            detailLines.length > 0 ? (
+                              <ul className="task-detail-list">
+                                {detailLines.map((line, index) => (
+                                  <li key={`${task.id}-detail-${index}`}>{line}</li>
+                                ))}
+                              </ul>
+                            ) : (
+                              <p className="muted-copy">No actions added yet. Use Edit to add task details.</p>
+                            )
                           )}
                         </div>
                       </div>

--- a/src/views/PlannerView.jsx
+++ b/src/views/PlannerView.jsx
@@ -30,6 +30,7 @@ export function PlannerView({
   editTitle,
   editMinutes,
   editDetails,
+  editCategory,
   applyDetailsToMatchingTemplates,
   collapsedPhases,
   quickAddInputs,
@@ -57,6 +58,7 @@ export function PlannerView({
   setEditTitle,
   setEditMinutes,
   setEditDetails,
+  setEditCategory,
   setApplyDetailsToMatchingTemplates,
   togglePhaseCollapsed,
   handleStartPhase,
@@ -70,6 +72,8 @@ export function PlannerView({
   cancelEditTask,
   deleteTask,
   addTaskToPhase,
+  addExerciseTaskToPhase,
+  moveTaskToPhase,
   addSuggestionTask,
   suggestNextAction,
   handleSkipCheckin,
@@ -144,6 +148,13 @@ export function PlannerView({
         </div>
       )}
 
+      <ExercisePlannerSection
+        phases={settings.phases}
+        activePhaseId={settings.activePhaseId}
+        moveTaskToPhase={moveTaskToPhase}
+        addExerciseTaskToPhase={addExerciseTaskToPhase}
+      />
+
       <div className="day-plan">
         {settings.phases.map((phase, phaseIndex) => (
           <PhaseSection
@@ -159,6 +170,7 @@ export function PlannerView({
             editTitle={editTitle}
             editMinutes={editMinutes}
             editDetails={editDetails}
+            editCategory={editCategory}
             applyDetailsToMatchingTemplates={applyDetailsToMatchingTemplates}
             collapsedPhases={collapsedPhases}
             expandedTaskDetails={expandedTaskDetails}
@@ -172,6 +184,7 @@ export function PlannerView({
             setEditTitle={setEditTitle}
             setEditMinutes={setEditMinutes}
             setEditDetails={setEditDetails}
+            setEditCategory={setEditCategory}
             setApplyDetailsToMatchingTemplates={setApplyDetailsToMatchingTemplates}
             toggleTaskDetails={toggleTaskDetails}
             setSettingsPatch={setSettingsPatch}
@@ -193,6 +206,88 @@ export function PlannerView({
         ))}
       </div>
     </>
+  );
+}
+
+function ExercisePlannerSection({
+  phases,
+  activePhaseId,
+  moveTaskToPhase,
+  addExerciseTaskToPhase,
+}) {
+  const [newExerciseTitle, setNewExerciseTitle] = useState('');
+  const [targetPhaseId, setTargetPhaseId] = useState(activePhaseId ?? phases[0]?.id ?? '');
+
+  const exerciseTasks = phases.flatMap((phase) =>
+    (phase.tasks ?? [])
+      .filter((task) => task.category === 'exercise')
+      .map((task) => ({
+        ...task,
+        phaseId: phase.id,
+        phaseName: phase.name,
+      }))
+  );
+
+  return (
+    <section className="card exercise-section">
+      <div className="section-header">
+        <div>
+          <p className="card-label">Exercise section</p>
+          <h3>Move exercises as your day shifts</h3>
+        </div>
+      </div>
+      <p className="muted-copy">Keep movement tasks flexible and reposition them across phases when energy or timing changes.</p>
+
+      <form
+        className="exercise-add-form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!targetPhaseId) return;
+          addExerciseTaskToPhase(targetPhaseId, newExerciseTitle);
+          setNewExerciseTitle('');
+        }}
+      >
+        <input
+          type="text"
+          value={newExerciseTitle}
+          placeholder="Add exercise task..."
+          onChange={(event) => setNewExerciseTitle(event.target.value)}
+        />
+        <select value={targetPhaseId} onChange={(event) => setTargetPhaseId(event.target.value)}>
+          {phases.map((phase) => (
+            <option key={phase.id} value={phase.id}>{phase.name}</option>
+          ))}
+        </select>
+        <button type="submit" className="secondary">Add exercise</button>
+      </form>
+
+      <div className="exercise-list">
+        {exerciseTasks.map((task) => (
+          <div key={task.id} className={`exercise-row ${task.done ? 'done' : ''}`}>
+            <div>
+              <strong>{task.title}</strong>
+              <p className="muted-copy">
+                {task.phaseName}
+                {task.minutes ? ` · ${task.minutes}m` : ''}
+              </p>
+            </div>
+            <select
+              value={task.phaseId}
+              onChange={(event) => moveTaskToPhase(task.phaseId, task.id, event.target.value)}
+            >
+              {phases.map((phase) => (
+                <option key={`${task.id}-${phase.id}`} value={phase.id}>
+                  Move to {phase.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        ))}
+        {exerciseTasks.length === 0 && (
+          <p className="muted-copy">No exercise tasks yet. Add one above and move it through your phases as needed.</p>
+        )}
+      </div>
+    </section>
   );
 }
 
@@ -457,6 +552,7 @@ function PhaseSection({
   editTitle,
   editMinutes,
   editDetails,
+  editCategory,
   applyDetailsToMatchingTemplates,
   collapsedPhases,
   expandedTaskDetails,
@@ -470,6 +566,7 @@ function PhaseSection({
   setEditTitle,
   setEditMinutes,
   setEditDetails,
+  setEditCategory,
   setApplyDetailsToMatchingTemplates,
   toggleTaskDetails,
   setSettingsPatch,
@@ -572,6 +669,16 @@ function PhaseSection({
                         value={editMinutes}
                         onChange={(event) => setEditMinutes(event.target.value)}
                       />
+                      <label className="task-edit-category">
+                        Category
+                        <select
+                          value={editCategory}
+                          onChange={(event) => setEditCategory(event.target.value)}
+                        >
+                          <option value="general">General</option>
+                          <option value="exercise">Exercise</option>
+                        </select>
+                      </label>
                       <textarea
                         className="task-details-input"
                         rows={4}
@@ -615,6 +722,7 @@ function PhaseSection({
                             </span>
                           )}
                           {task.minutes && !timer && <span className="task-duration">{task.minutes} min</span>}
+                          {task.category === 'exercise' && <span className="task-category-badge">Exercise</span>}
                           {timer && (
                             <span className="task-timer-running">
                               {timerRunning ? formatSeconds(timerSeconds) : `${formatSeconds(timerSeconds)} left`}

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -10,6 +10,8 @@ export function SettingsView({
   deleteTask,
   addTemplateTaskToPhase,
   insertPhaseAt,
+  updateTaskDetailsInPhase,
+  applyTaskDetailsToMatchingTemplates,
 }) {
   return (
     <section className="card">
@@ -55,9 +57,27 @@ export function SettingsView({
               <p className="field-label">Repeating tasks</p>
               {phase.tasks.filter((task) => task.type === 'template').map((task) => (
                 <div key={task.id} className="settings-template-task-row">
-                  <span className="settings-template-task-title">{task.title}</span>
-                  {task.minutes && <span className="muted-copy">{task.minutes}m</span>}
-                  <button className="ghost small danger-text" onClick={() => deleteTask(phase.id, task.id)}>x</button>
+                  <div className="settings-template-header">
+                    <span className="settings-template-task-title">{task.title}</span>
+                    {task.minutes && <span className="muted-copy">{task.minutes}m</span>}
+                    <button className="ghost small danger-text" onClick={() => deleteTask(phase.id, task.id)}>x</button>
+                  </div>
+                  <textarea
+                    className="settings-template-details-input"
+                    rows={3}
+                    placeholder="Add action details for this task (one action per line)."
+                    value={task.details ?? ''}
+                    onChange={(event) => updateTaskDetailsInPhase(phase.id, task.id, event.target.value)}
+                  />
+                  <div className="button-row">
+                    <button
+                      type="button"
+                      className="ghost small"
+                      onClick={() => applyTaskDetailsToMatchingTemplates(task.title, task.details ?? '')}
+                    >
+                      Apply details to matching repeating tasks
+                    </button>
+                  </div>
                 </div>
               ))}
               <form


### PR DESCRIPTION
## Summary
- add task action/details support to the task model and persisted state normalization
- add expandable actions UI in planner tasks so users can review detailed steps inline
- extend task edit flow with details textarea and option to apply details to matching repeating tasks
- add settings-level details editor for repeating tasks plus one-click propagate across matching template task names

Closes #18

## Testing
- npm test
- npm run build
- node --check src/lib/focusFlowCore.js
- node --check server/defaultState.js