### PR TITLE
Harden user auth flows and expand admin testing controls

### DIFF
--- a/server/createApp.js
+++ b/server/createApp.js
@@ -13,6 +13,8 @@ import { buildDefaultState, normalizeState } from './defaultState.js';
 import { SESSION_TTL_MS } from './db.js';
 
 const SESSION_COOKIE = 'focus_flow_session';
+const LOGIN_FAILURE_LIMIT = Math.max(1, Number(process.env.LOGIN_FAILURE_LIMIT ?? 5) || 5);
+const LOGIN_LOCK_MS = Math.max(60_000, Number(process.env.LOGIN_LOCK_MS ?? 15 * 60 * 1000) || (15 * 60 * 1000));
 const WEATHER_CODE_LABELS = {
   0: 'clear',
   1: 'mostly clear',
@@ -43,6 +45,31 @@ const WEATHER_CODE_LABELS = {
   96: 'thunderstorms with hail',
   99: 'thunderstorms with hail',
 };
+
+function parseIsoDate(value) {
+  if (!value) {
+    return null;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp) : null;
+}
+
+function getLoginLockState(user, now = new Date()) {
+  const lockedUntilDate = parseIsoDate(user?.locked_until);
+  if (!lockedUntilDate || lockedUntilDate <= now) {
+    return {
+      locked: false,
+      lockedUntil: null,
+      retryAfterSeconds: 0,
+    };
+  }
+  const retryAfterSeconds = Math.max(1, Math.ceil((lockedUntilDate.getTime() - now.getTime()) / 1000));
+  return {
+    locked: true,
+    lockedUntil: lockedUntilDate.toISOString(),
+    retryAfterSeconds,
+  };
+}
 
 function parseCookies(cookieHeader = '') {
   return Object.fromEntries(
@@ -141,6 +168,7 @@ export function createApp({
   }
 
   function publicUser(row) {
+    const lockState = getLoginLockState(row);
     return {
       id: row.id,
       email: row.email,
@@ -148,6 +176,9 @@ export function createApp({
       role: row.role,
       authProvider: row.auth_provider ?? 'local',
       accountStatus: row.account_status ?? 'active',
+      failedLoginAttempts: Number(row.failed_login_attempts ?? 0),
+      lastFailedLoginAt: row.last_failed_login_at ?? null,
+      loginLockedUntil: lockState.locked ? lockState.lockedUntil : null,
     };
   }
 
@@ -352,6 +383,36 @@ export function createApp({
       .run(nextSessionExpiry(), token);
   }
 
+  function recordLoginFailure(userId, now = new Date()) {
+    const row = db
+      .prepare('SELECT failed_login_attempts, locked_until FROM users WHERE id = ?')
+      .get(userId);
+    const currentAttempts = Number(row?.failed_login_attempts ?? 0);
+    const nextAttempts = currentAttempts + 1;
+    const lock = nextAttempts >= LOGIN_FAILURE_LIMIT;
+    const lockUntilIso = lock ? new Date(now.getTime() + LOGIN_LOCK_MS).toISOString() : null;
+
+    db.prepare(
+      `UPDATE users
+       SET failed_login_attempts = ?, last_failed_login_at = ?, locked_until = ?
+       WHERE id = ?`
+    ).run(lock ? 0 : nextAttempts, now.toISOString(), lockUntilIso, userId);
+
+    return {
+      lockApplied: lock,
+      lockUntil: lockUntilIso,
+      attemptsRemaining: lock ? 0 : Math.max(0, LOGIN_FAILURE_LIMIT - nextAttempts),
+    };
+  }
+
+  function clearLoginFailures(userId) {
+    db.prepare(
+      `UPDATE users
+       SET failed_login_attempts = 0, last_failed_login_at = NULL, locked_until = NULL
+       WHERE id = ?`
+    ).run(userId);
+  }
+
   function requireAuth(req, res, next) {
     const cookies = parseCookies(req.headers.cookie);
     const token = cookies[SESSION_COOKIE];
@@ -365,7 +426,7 @@ export function createApp({
     const row = db
       .prepare(
         `SELECT users.id, users.email, users.display_name, users.role, users.auth_provider, users.auth_subject,
-                users.account_status, users.settings_json
+                users.account_status, users.failed_login_attempts, users.last_failed_login_at, users.locked_until, users.settings_json
          FROM sessions
          JOIN users ON users.id = sessions.user_id
          WHERE sessions.token = ?
@@ -459,7 +520,7 @@ export function createApp({
 
     const user = db
       .prepare(
-        'SELECT id, email, display_name, role, auth_provider, auth_subject, account_status, settings_json FROM users WHERE id = ?'
+        'SELECT id, email, display_name, role, auth_provider, auth_subject, account_status, failed_login_attempts, last_failed_login_at, locked_until, settings_json FROM users WHERE id = ?'
       )
       .get(req.user.id);
     return res.json(authResponseForUser(user));
@@ -500,7 +561,9 @@ export function createApp({
     setSessionCookie(res, token);
 
     const user = db
-      .prepare('SELECT id, email, display_name, role, auth_provider, auth_subject, account_status, settings_json FROM users WHERE id = ?')
+      .prepare(
+        'SELECT id, email, display_name, role, auth_provider, auth_subject, account_status, failed_login_attempts, last_failed_login_at, locked_until, settings_json FROM users WHERE id = ?'
+      )
       .get(id);
 
     writeAuditEvent({
@@ -521,19 +584,45 @@ export function createApp({
 
     const user = db
       .prepare(
-        `SELECT id, email, display_name, role, password_hash, auth_provider, auth_subject, account_status, settings_json
+        `SELECT id, email, display_name, role, password_hash, auth_provider, auth_subject, account_status,
+                failed_login_attempts, last_failed_login_at, locked_until, settings_json
          FROM users
          WHERE email = ?`
       )
       .get(email);
 
-    if (!user || user.account_status !== 'active' || !canUsePasswordAuth(user) || !verifyPassword(password, user.password_hash)) {
+    const lockState = getLoginLockState(user);
+    if (lockState.locked) {
       writeAuditEvent({
-        eventType: 'auth.login_failed',
+        eventType: 'auth.login_blocked',
         level: 'warn',
+        actorUserId: user.id,
+        requestId: req.requestId,
+        message: `Blocked login for locked account: ${email || 'unknown email'}`,
+        metadata: { lockedUntil: lockState.lockedUntil, retryAfterSeconds: lockState.retryAfterSeconds },
+      });
+      res.setHeader('Retry-After', String(lockState.retryAfterSeconds));
+      return res.status(429).json({ error: 'Too many login attempts. Try again shortly.' });
+    }
+
+    const passwordValid = user && user.account_status === 'active' && canUsePasswordAuth(user) && verifyPassword(password, user.password_hash);
+    if (!passwordValid) {
+      let lockApplied = false;
+      if (user && user.account_status === 'active' && canUsePasswordAuth(user)) {
+        const failureState = recordLoginFailure(user.id);
+        lockApplied = failureState.lockApplied;
+      }
+      writeAuditEvent({
+        eventType: lockApplied ? 'auth.login_locked' : 'auth.login_failed',
+        level: 'warn',
+        actorUserId: user?.id ?? null,
         requestId: req.requestId,
         message: `Failed login attempt for ${email || 'unknown email'}`,
       });
+      if (lockApplied) {
+        res.setHeader('Retry-After', String(Math.ceil(LOGIN_LOCK_MS / 1000)));
+        return res.status(429).json({ error: 'Too many login attempts. Try again shortly.' });
+      }
       return res.status(401).json({ error: 'Invalid email or password.' });
     }
 
@@ -542,6 +631,7 @@ export function createApp({
       db.prepare('UPDATE users SET role = ? WHERE id = ?').run(resolvedRole, user.id);
       user.role = resolvedRole;
     }
+    clearLoginFailures(user.id);
     db.prepare('UPDATE users SET last_login_at = ? WHERE id = ?').run(new Date().toISOString(), user.id);
     const token = createSession(user.id);
     setSessionCookie(res, token);
@@ -623,9 +713,10 @@ export function createApp({
         SUM(CASE WHEN role = 'admin' THEN 1 ELSE 0 END) AS adminUsers,
         SUM(CASE WHEN auth_provider = 'local' THEN 1 ELSE 0 END) AS localUsers,
         SUM(CASE WHEN account_status = 'active' THEN 1 ELSE 0 END) AS activeUsers,
-        SUM(CASE WHEN account_status = 'suspended' THEN 1 ELSE 0 END) AS suspendedUsers
+        SUM(CASE WHEN account_status = 'suspended' THEN 1 ELSE 0 END) AS suspendedUsers,
+        SUM(CASE WHEN locked_until IS NOT NULL AND locked_until > ? THEN 1 ELSE 0 END) AS lockedUsers
       FROM users
-    `).get();
+    `).get(new Date().toISOString());
     const recentEvents = db.prepare(`
       SELECT id, event_type, level, actor_user_id, target_user_id, request_id, message, metadata_json, created_at
       FROM audit_events
@@ -651,6 +742,7 @@ export function createApp({
         localUsers: Number(counts.localUsers ?? 0),
         activeUsers: Number(counts.activeUsers ?? 0),
         suspendedUsers: Number(counts.suspendedUsers ?? 0),
+        lockedUsers: Number(counts.lockedUsers ?? 0),
       },
       recentEvents,
       auth: getAuthConfig(),
@@ -662,6 +754,7 @@ export function createApp({
     const nowIso = new Date().toISOString();
     const sql = `
       SELECT id, email, display_name, role, auth_provider, account_status, created_at, last_login_at,
+             failed_login_attempts, last_failed_login_at, locked_until,
              (
                SELECT COUNT(*)
                FROM sessions
@@ -684,6 +777,9 @@ export function createApp({
       activeSessionCount: Number(row.active_session_count ?? 0),
       createdAt: row.created_at,
       lastLoginAt: row.last_login_at,
+      failedLoginAttempts: Number(row.failed_login_attempts ?? 0),
+      lastFailedLoginAt: row.last_failed_login_at,
+      loginLockedUntil: getLoginLockState(row).locked ? row.locked_until : null,
     }));
 
     res.json({ users });
@@ -694,7 +790,8 @@ export function createApp({
     const nowIso = new Date().toISOString();
     const target = db
       .prepare(
-        `SELECT id, email, display_name, role, auth_provider, account_status, created_at, last_login_at, settings_json
+        `SELECT id, email, display_name, role, auth_provider, account_status, created_at, last_login_at,
+                failed_login_attempts, last_failed_login_at, locked_until, settings_json
          FROM users
          WHERE id = ?`
       )
@@ -758,17 +855,28 @@ export function createApp({
 
   app.post('/api/admin/users/:userId/reset', requireAuth, requireAdmin, (req, res) => {
     const targetUserId = String(req.params.userId ?? '').trim();
-    if (targetUserId === req.user.id) {
-      return res.status(400).json({ error: 'Reset your own account manually instead of using the admin reset.' });
+    const preserveCurrentSession = Boolean(req.body?.preserveCurrentSession);
+    if (targetUserId === req.user.id && !preserveCurrentSession) {
+      return res.status(400).json({ error: 'Use preserveCurrentSession to reset your own account without ending your session.' });
     }
-    const target = db.prepare('SELECT id, email, display_name, role, auth_provider, account_status FROM users WHERE id = ?').get(targetUserId);
+    const target = db
+      .prepare(
+        'SELECT id, email, display_name, role, auth_provider, account_status, failed_login_attempts, last_failed_login_at, locked_until FROM users WHERE id = ?'
+      )
+      .get(targetUserId);
     if (!target) {
       return res.status(404).json({ error: 'User not found.' });
     }
 
     db.prepare('UPDATE users SET settings_json = ? WHERE id = ?')
       .run(JSON.stringify(buildDefaultState()), targetUserId);
-    db.prepare('DELETE FROM sessions WHERE user_id = ?').run(targetUserId);
+    let preservedCurrentSession = false;
+    if (targetUserId === req.user.id && preserveCurrentSession) {
+      db.prepare('DELETE FROM sessions WHERE user_id = ? AND token <> ?').run(targetUserId, req.sessionToken);
+      preservedCurrentSession = true;
+    } else {
+      db.prepare('DELETE FROM sessions WHERE user_id = ?').run(targetUserId);
+    }
 
     writeAuditEvent({
       eventType: 'admin.user_reset',
@@ -777,10 +885,12 @@ export function createApp({
       targetUserId,
       requestId: req.requestId,
       message: `User reset by admin: ${target.email}`,
+      metadata: { preservedCurrentSession },
     });
 
     res.json({
       ok: true,
+      preservedCurrentSession,
       user: publicUser(target),
     });
   });
@@ -853,7 +963,11 @@ export function createApp({
       return res.status(400).json({ error: 'Admin users cannot suspend their own account.' });
     }
 
-    const target = db.prepare('SELECT id, email, display_name, role, auth_provider, account_status FROM users WHERE id = ?').get(targetUserId);
+    const target = db
+      .prepare(
+        'SELECT id, email, display_name, role, auth_provider, account_status, failed_login_attempts, last_failed_login_at, locked_until FROM users WHERE id = ?'
+      )
+      .get(targetUserId);
     if (!target) {
       return res.status(404).json({ error: 'User not found.' });
     }
@@ -868,6 +982,9 @@ export function createApp({
 
     const updatedAt = new Date().toISOString();
     db.prepare('UPDATE users SET account_status = ? WHERE id = ?').run(nextStatus, targetUserId);
+    if (nextStatus === 'active') {
+      clearLoginFailures(targetUserId);
+    }
     let revokedSessions = 0;
     if (nextStatus === 'suspended') {
       const result = db.prepare('DELETE FROM sessions WHERE user_id = ?').run(targetUserId);
@@ -925,6 +1042,37 @@ export function createApp({
       revokedSessions,
       preservedCurrentSession,
       user: publicUser(target),
+    });
+  });
+
+  app.post('/api/admin/users/:userId/unlock', requireAuth, requireAdmin, (req, res) => {
+    const targetUserId = String(req.params.userId ?? '').trim();
+    const target = db
+      .prepare(
+        'SELECT id, email, display_name, role, auth_provider, account_status, failed_login_attempts, last_failed_login_at, locked_until FROM users WHERE id = ?'
+      )
+      .get(targetUserId);
+    if (!target) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    const lockState = getLoginLockState(target);
+    const hadFailureState = lockState.locked || Number(target.failed_login_attempts ?? 0) > 0 || Boolean(target.last_failed_login_at);
+    clearLoginFailures(targetUserId);
+
+    writeAuditEvent({
+      eventType: 'admin.user_unlock',
+      level: 'warn',
+      actorUserId: req.user.id,
+      targetUserId,
+      requestId: req.requestId,
+      message: `User auth lock reset by admin: ${target.email}`,
+      metadata: { hadFailureState },
+    });
+
+    return res.json({
+      ok: true,
+      changed: hadFailureState,
     });
   });
 

--- a/server/db.js
+++ b/server/db.js
@@ -25,6 +25,9 @@ const USERS_TABLE_BODY = `
     auth_provider TEXT NOT NULL DEFAULT 'local',
     auth_subject TEXT NOT NULL,
     account_status TEXT NOT NULL DEFAULT 'active',
+    failed_login_attempts INTEGER NOT NULL DEFAULT 0,
+    last_failed_login_at TEXT,
+    locked_until TEXT,
     settings_json TEXT NOT NULL,
     created_at TEXT NOT NULL,
     last_login_at TEXT
@@ -91,6 +94,9 @@ function rebuildUsersTableIfNeeded(db) {
     !columnNames.has('auth_provider') ||
     !columnNames.has('auth_subject') ||
     !columnNames.has('account_status') ||
+    !columnNames.has('failed_login_attempts') ||
+    !columnNames.has('last_failed_login_at') ||
+    !columnNames.has('locked_until') ||
     !columnNames.has('last_login_at') ||
     passwordHashColumn?.notnull === 1;
 
@@ -106,6 +112,11 @@ function rebuildUsersTableIfNeeded(db) {
   const accountStatusExpression = columnNames.has('account_status')
     ? "COALESCE(account_status, 'active')"
     : "'active'";
+  const failedAttemptsExpression = columnNames.has('failed_login_attempts')
+    ? 'COALESCE(failed_login_attempts, 0)'
+    : '0';
+  const lastFailedLoginExpression = columnNames.has('last_failed_login_at') ? 'last_failed_login_at' : 'NULL';
+  const lockedUntilExpression = columnNames.has('locked_until') ? 'locked_until' : 'NULL';
   const lastLoginExpression = columnNames.has('last_login_at') ? 'last_login_at' : 'NULL';
   const passwordHashExpression = columnNames.has('password_hash') ? 'password_hash' : 'NULL';
 
@@ -123,6 +134,9 @@ function rebuildUsersTableIfNeeded(db) {
         auth_provider,
         auth_subject,
         account_status,
+        failed_login_attempts,
+        last_failed_login_at,
+        locked_until,
         settings_json,
         created_at,
         last_login_at
@@ -136,6 +150,9 @@ function rebuildUsersTableIfNeeded(db) {
         ${authProviderExpression},
         ${authSubjectExpression},
         ${accountStatusExpression},
+        ${failedAttemptsExpression},
+        ${lastFailedLoginExpression},
+        ${lockedUntilExpression},
         settings_json,
         created_at,
         ${lastLoginExpression}
@@ -251,6 +268,7 @@ function ensureIndexes(db) {
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_users_role ON users(role);
     CREATE INDEX IF NOT EXISTS idx_users_account_status ON users(account_status);
+    CREATE INDEX IF NOT EXISTS idx_users_locked_until ON users(locked_until);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_users_auth_identity ON users(auth_provider, auth_subject);
     CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
     CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,6 +80,7 @@ export default function App() {
     loadedSettingsRef,
     handleAuthSubmit,
     claimAdminAccess,
+    refreshAuthenticatedSession,
     handleLogout,
     updateAuthForm,
   } = useAuthSession({
@@ -110,6 +111,7 @@ export default function App() {
     user,
     siteView,
     onFeatureFlagsChange: setFeatureFlags,
+    refreshAuthenticatedSession,
   });
 
   const activePhase = useMemo(

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -105,6 +105,7 @@ export default function App() {
     revokeUserSessions,
     seedDemoState,
     clearUserActivity,
+    unlockUserAuth,
   } = useAdminData({
     user,
     siteView,
@@ -852,6 +853,7 @@ export default function App() {
             revokeUserSessions={revokeUserSessions}
             seedDemoState={seedDemoState}
             clearUserActivity={clearUserActivity}
+            unlockUserAuth={unlockUserAuth}
           />
         )}
 

--- a/src/hooks/useAdminData.js
+++ b/src/hooks/useAdminData.js
@@ -69,13 +69,14 @@ export function useAdminData({ user, siteView, onFeatureFlagsChange }) {
     }
   }
 
-  async function resetUserState(targetUserId) {
+  async function resetUserState(targetUserId, options = {}) {
     setAdminStatus('');
     try {
       await api(`/api/admin/users/${encodeURIComponent(targetUserId)}/reset`, {
         method: 'POST',
+        body: JSON.stringify(options),
       });
-      setAdminStatus('User state reset.');
+      setAdminStatus(options.preserveCurrentSession ? 'Your state was reset and your current session was preserved.' : 'User state reset.');
       await Promise.all([refreshAdminSummary(), searchAdminUsers()]);
       if (selectedAdminUser?.user?.id === targetUserId) {
         await inspectUser(targetUserId);
@@ -183,6 +184,25 @@ export function useAdminData({ user, siteView, onFeatureFlagsChange }) {
     }
   }
 
+  async function unlockUserAuth(targetUserId) {
+    setAdminStatus('');
+    setAdminLoading(true);
+    try {
+      const data = await api(`/api/admin/users/${encodeURIComponent(targetUserId)}/unlock`, {
+        method: 'POST',
+      });
+      setAdminStatus(data.changed ? 'Auth lock state cleared.' : 'No lock state to clear.');
+      await Promise.all([refreshAdminSummary(), searchAdminUsers()]);
+      if (selectedAdminUser?.user?.id === targetUserId) {
+        await inspectUser(targetUserId);
+      }
+    } catch (error) {
+      setAdminStatus(error.message);
+    } finally {
+      setAdminLoading(false);
+    }
+  }
+
   useEffect(() => {
     if (siteView === 'admin' && user?.role === 'admin') {
       refreshAdminSummary();
@@ -208,5 +228,6 @@ export function useAdminData({ user, siteView, onFeatureFlagsChange }) {
     revokeUserSessions,
     seedDemoState,
     clearUserActivity,
+    unlockUserAuth,
   };
 }

--- a/src/hooks/useAdminData.js
+++ b/src/hooks/useAdminData.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { api } from '../lib/api.js';
 import { DEFAULT_FEATURE_FLAGS } from '../lib/focusFlowData.js';
 
-export function useAdminData({ user, siteView, onFeatureFlagsChange }) {
+export function useAdminData({ user, siteView, onFeatureFlagsChange, refreshAuthenticatedSession }) {
   const [adminSummary, setAdminSummary] = useState({
     flags: DEFAULT_FEATURE_FLAGS,
     metrics: null,
@@ -76,6 +76,9 @@ export function useAdminData({ user, siteView, onFeatureFlagsChange }) {
         method: 'POST',
         body: JSON.stringify(options),
       });
+      if (options.preserveCurrentSession && targetUserId === user?.id) {
+        await refreshAuthenticatedSession?.();
+      }
       setAdminStatus(options.preserveCurrentSession ? 'Your state was reset and your current session was preserved.' : 'User state reset.');
       await Promise.all([refreshAdminSummary(), searchAdminUsers()]);
       if (selectedAdminUser?.user?.id === targetUserId) {

--- a/src/hooks/useAuthSession.js
+++ b/src/hooks/useAuthSession.js
@@ -127,6 +127,15 @@ export function useAuthSession({ onAuthenticated, onSignedOut } = {}) {
     }
   }
 
+  async function refreshAuthenticatedSession() {
+    const authMeta = await api('/api/auth/config')
+      .then((data) => data?.auth ?? DEFAULT_AUTH_CONFIG)
+      .catch(() => DEFAULT_AUTH_CONFIG);
+    const data = await api('/api/auth/session');
+    applyAuthenticatedPayload(data, authMeta);
+    return data;
+  }
+
   async function handleLogout() {
     try {
       await api('/api/auth/logout', { method: 'POST' });
@@ -171,6 +180,7 @@ export function useAuthSession({ onAuthenticated, onSignedOut } = {}) {
     loadedSettingsRef,
     handleAuthSubmit,
     claimAdminAccess,
+    refreshAuthenticatedSession,
     handleLogout,
     updateAuthForm,
   };

--- a/src/views/AdminView.jsx
+++ b/src/views/AdminView.jsx
@@ -17,6 +17,7 @@ export function AdminView({
   revokeUserSessions,
   seedDemoState,
   clearUserActivity,
+  unlockUserAuth,
 }) {
   function confirmAndRun(message, action) {
     if (!window.confirm(message)) {
@@ -79,6 +80,10 @@ export function AdminView({
             <strong>{adminSummary.metrics?.suspendedUsers ?? 0}</strong>
           </div>
           <div className="admin-metric">
+            <span>Locked logins</span>
+            <strong>{adminSummary.metrics?.lockedUsers ?? 0}</strong>
+          </div>
+          <div className="admin-metric">
             <span>Flags</span>
             <strong>{(adminSummary.flags ?? featureFlags).length}</strong>
           </div>
@@ -122,6 +127,15 @@ export function AdminView({
                 <p className="muted-copy">
                   Active sessions {adminUser.activeSessionCount ?? 0}
                 </p>
+                {adminUser.loginLockedUntil && (
+                  <p className="muted-copy">Login locked until {new Date(adminUser.loginLockedUntil).toLocaleString()}</p>
+                )}
+                {!adminUser.loginLockedUntil && (adminUser.failedLoginAttempts ?? 0) > 0 && (
+                  <p className="muted-copy">
+                    Failed login attempts {adminUser.failedLoginAttempts}
+                    {adminUser.lastFailedLoginAt ? ` · last ${new Date(adminUser.lastFailedLoginAt).toLocaleString()}` : ''}
+                  </p>
+                )}
                 {adminUser.lastLoginAt && (
                   <p className="muted-copy">Last login {new Date(adminUser.lastLoginAt).toLocaleString()}</p>
                 )}
@@ -157,15 +171,27 @@ export function AdminView({
                 </button>
                 <button
                   className="ghost small"
-                  disabled={adminUser.id === user.id}
                   onClick={() =>
                     confirmAndRun(
-                      `Reset all planner state for ${adminUser.email}?`,
-                      () => resetUserState(adminUser.id)
+                      adminUser.id === user.id
+                        ? 'Reset your own planner state and keep this current session?'
+                        : `Reset all planner state for ${adminUser.email}?`,
+                      () => resetUserState(adminUser.id, adminUser.id === user.id ? { preserveCurrentSession: true } : undefined)
                     )
                   }
                 >
-                  {adminUser.id === user.id ? 'Current user' : 'Reset state'}
+                  {adminUser.id === user.id ? 'Reset my state' : 'Reset state'}
+                </button>
+                <button
+                  className="ghost small"
+                  onClick={() =>
+                    confirmAndRun(
+                      `Clear login lock state for ${adminUser.email}?`,
+                      () => unlockUserAuth(adminUser.id)
+                    )
+                  }
+                >
+                  Unlock login
                 </button>
                 <button
                   className="ghost small"
@@ -223,7 +249,14 @@ export function AdminView({
               <span>Completed tasks</span>
               <strong>{selectedAdminUser.plannerStateSummary?.completedTasks ?? 0}</strong>
             </div>
+            <div className="admin-metric">
+              <span>Failed logins</span>
+              <strong>{selectedAdminUser.user.failedLoginAttempts ?? 0}</strong>
+            </div>
           </div>
+          {selectedAdminUser.user.loginLockedUntil && (
+            <p className="muted-copy">Login locked until {new Date(selectedAdminUser.user.loginLockedUntil).toLocaleString()}</p>
+          )}
           <p className="muted-copy">
             Routine {selectedAdminUser.plannerStateSummary?.routineType ?? 'session'} · Health {selectedAdminUser.plannerStateSummary?.healthState ?? 'steady'} · Setup {selectedAdminUser.plannerStateSummary?.setupComplete ? 'complete' : 'pending'} · Onboarding {selectedAdminUser.plannerStateSummary?.onboardingComplete ? 'complete' : 'pending'}
           </p>

--- a/test/api-routes.test.js
+++ b/test/api-routes.test.js
@@ -193,6 +193,66 @@ test('admin reset revokes another user session and resets their state', async ()
   }
 });
 
+test('admin can reset their own state while preserving current session', async () => {
+  const server = await startTestServer({
+    name: 'focusflow-admin-self-reset',
+    adminEmails: ['admin@example.com'],
+  });
+  try {
+    const adminRegistration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Admin',
+        email: 'admin@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const adminCookie = readCookie(adminRegistration.response.headers.get('set-cookie'));
+    const adminId = adminRegistration.body.user.id;
+
+    server.db
+      .prepare("UPDATE users SET settings_json = ? WHERE id = ?")
+      .run(JSON.stringify({
+        phases: [],
+        activePhaseId: null,
+        routineType: 'integration',
+        healthState: 'drained',
+        preferences: {
+          setupComplete: true,
+          onboardingComplete: true,
+        },
+      }), adminId);
+
+    const reset = await server.request(`/api/admin/users/${adminId}/reset`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: adminCookie,
+      },
+      body: JSON.stringify({ preserveCurrentSession: true }),
+    });
+
+    assert.equal(reset.response.status, 200);
+    assert.equal(reset.body.ok, true);
+    assert.equal(reset.body.preservedCurrentSession, true);
+
+    const session = await server.request('/api/auth/session', {
+      headers: { cookie: adminCookie },
+    });
+    assert.equal(session.response.status, 200);
+
+    const resetUser = server.db
+      .prepare('SELECT settings_json FROM users WHERE id = ?')
+      .get(adminId);
+    const parsedState = JSON.parse(resetUser.settings_json);
+    assert.equal(parsedState.routineType, 'session');
+    assert.equal(parsedState.preferences.setupComplete, false);
+  } finally {
+    await server.close();
+  }
+});
+
 test('admin can suspend and reactivate accounts', async () => {
   const server = await startTestServer({
     name: 'focusflow-admin-account-status',
@@ -260,6 +320,95 @@ test('admin can suspend and reactivate accounts', async () => {
       }),
     });
     assert.equal(loginAgain.response.status, 200);
+  } finally {
+    await server.close();
+  }
+});
+
+test('locks login after repeated failures and lets admin unlock the account', async () => {
+  const server = await startTestServer({
+    name: 'focusflow-login-lock',
+    adminEmails: ['admin@example.com'],
+  });
+  try {
+    const adminRegistration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Admin',
+        email: 'admin@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const adminCookie = readCookie(adminRegistration.response.headers.get('set-cookie'));
+
+    const userRegistration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Jordan',
+        email: 'jordan@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const userId = userRegistration.body.user.id;
+
+    for (let index = 0; index < 4; index += 1) {
+      const failed = await server.request('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: 'jordan@example.com',
+          password: 'wrong-password',
+        }),
+      });
+      assert.equal(failed.response.status, 401);
+    }
+
+    const lockFailure = await server.request('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'jordan@example.com',
+        password: 'wrong-password',
+      }),
+    });
+    assert.equal(lockFailure.response.status, 429);
+    assert.equal(lockFailure.body.error, 'Too many login attempts. Try again shortly.');
+
+    const lockedCorrectPassword = await server.request('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'jordan@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    assert.equal(lockedCorrectPassword.response.status, 429);
+
+    const summaryWhileLocked = await server.request('/api/admin/summary', {
+      headers: { cookie: adminCookie },
+    });
+    assert.equal(summaryWhileLocked.response.status, 200);
+    assert.equal(summaryWhileLocked.body.metrics.lockedUsers, 1);
+
+    const unlock = await server.request(`/api/admin/users/${userId}/unlock`, {
+      method: 'POST',
+      headers: { cookie: adminCookie },
+    });
+    assert.equal(unlock.response.status, 200);
+    assert.equal(unlock.body.ok, true);
+    assert.equal(unlock.body.changed, true);
+
+    const loginAfterUnlock = await server.request('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'jordan@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    assert.equal(loginAfterUnlock.response.status, 200);
   } finally {
     await server.close();
   }

--- a/test/db-migration.test.js
+++ b/test/db-migration.test.js
@@ -90,7 +90,22 @@ test('migrates a direct legacy database with sessions missing expires_at', () =>
 
   assert.deepEqual(
     userColumns,
-    ['id', 'email', 'password_hash', 'display_name', 'role', 'auth_provider', 'auth_subject', 'account_status', 'settings_json', 'created_at', 'last_login_at']
+    [
+      'id',
+      'email',
+      'password_hash',
+      'display_name',
+      'role',
+      'auth_provider',
+      'auth_subject',
+      'account_status',
+      'failed_login_attempts',
+      'last_failed_login_at',
+      'locked_until',
+      'settings_json',
+      'created_at',
+      'last_login_at',
+    ]
   );
   assert.deepEqual(sessionColumns, ['token', 'user_id', 'created_at', 'expires_at']);
   assert.equal(tableSql.includes('users_legacy'), false);


### PR DESCRIPTION
## Summary
- add persistent login-failure tracking with temporary lockout after repeated bad passwords
- add admin visibility for locked logins and failed attempts, plus an Unlock login admin action
- allow admins to reset their own planner state while preserving their current session for local testing workflows
- extend migration coverage for new user auth columns and add API tests for lock/unlock and self-reset

## Validation
- npm test
- npm run build
