### PR TITLE
Polish mobile planner layout (round 2)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -694,8 +694,9 @@ h3 {
 
 .suggestion-strip {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.45rem;
-  overflow-x: auto;
+  overflow: visible;
   padding-bottom: 0.2rem;
 }
 
@@ -1391,9 +1392,10 @@ h3 {
 
 /* Phase map */
 .phase-map-card {
-  display: flex;
-  overflow-x: auto;
-  gap: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+  gap: 0.35rem;
+  overflow: visible;
   padding: 0.32rem;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--line);
@@ -1402,8 +1404,8 @@ h3 {
 }
 
 .phase-map-segment {
-  flex: 1;
-  min-width: 6rem;
+  min-width: 0;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 0.18rem;
@@ -2015,6 +2017,11 @@ h3 {
     padding: 0 1rem 0.5rem;
   }
 
+  .suggestion-strip {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+
   .suggest-btn {
     margin: 0.1rem 1rem 0.75rem;
   }
@@ -2063,11 +2070,16 @@ h3 {
   }
 
   .phase-map-card {
+    display: flex;
+    overflow-x: auto;
+    gap: 0;
     padding: 0.4rem;
   }
 
   .phase-map-segment {
+    flex: 1;
     min-width: 6.2rem;
+    width: auto;
     padding: 0.55rem 0.65rem;
   }
 
@@ -2123,7 +2135,6 @@ h3 {
 
 @media (max-width: 480px) {
   .phase-map-segment {
-    min-width: 5rem;
     padding: 0.4rem 0.45rem;
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -228,13 +228,13 @@ button.small {
   display: block;
   max-width: 760px;
   margin: 0 auto;
-  padding: 0.65rem;
+  padding: 0.6rem 0.6rem calc(1rem + env(safe-area-inset-bottom));
 }
 
 .main-grid,
 .main-stack {
   display: grid;
-  gap: 0.88rem;
+  gap: 0.78rem;
 }
 
 .main-grid,
@@ -250,7 +250,7 @@ button.small {
   border-radius: 18px;
   border: 1px solid var(--line);
   background: var(--surface);
-  padding: 0.9rem;
+  padding: 0.8rem;
   backdrop-filter: blur(16px);
   box-shadow: 0 1px 0 rgba(255,255,255,0.18) inset, 0 10px 30px rgba(28, 51, 74, 0.12);
 }
@@ -262,19 +262,20 @@ button.small {
 }
 
 .topbar-card {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  flex-wrap: wrap;
-  gap: 0.8rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.45rem;
   position: static;
   z-index: 3;
+  padding: 0.62rem 0.75rem;
+  border-radius: 14px;
 }
 
 .topbar-app-name {
   text-transform: uppercase;
   letter-spacing: 0.13em;
-  font-size: 0.7rem;
+  font-size: 0.66rem;
   color: var(--primary);
   font-weight: 800;
   opacity: 0.75;
@@ -282,11 +283,15 @@ button.small {
 
 .topbar-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.42rem;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   justify-content: flex-end;
-  margin-left: auto;
+  min-width: fit-content;
+}
+
+.topbar-actions .save-dot {
+  display: none;
 }
 
 .profile-menu-wrap {
@@ -294,12 +299,12 @@ button.small {
 }
 
 .profile-trigger {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.3rem;
+  height: 2.3rem;
   padding: 0;
   border-radius: 999px;
   font-weight: 800;
-  font-size: 1rem;
+  font-size: 0.92rem;
   background: linear-gradient(135deg, #e07b5c, #c4604a);
   box-shadow: 0 2px 10px rgba(224, 123, 92, 0.4);
 }
@@ -931,7 +936,7 @@ h3 {
 
 .exercise-section {
   display: grid;
-  gap: 0.65rem;
+  gap: 0.58rem;
 }
 
 .exercise-add-form {
@@ -1148,32 +1153,37 @@ h3 {
 .context-strip {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  padding: 0.85rem 1rem;
+  gap: 0.42rem;
+  padding: 0.72rem 0.82rem;
 }
 
 .context-strip-top {
+  display: grid;
+  gap: 0.28rem;
+}
+
+.context-strip-top > div {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 0.5rem 1rem;
+  gap: 0.2rem;
 }
 
 .context-greeting {
   font-weight: 800;
-  font-size: 1.3rem;
+  font-size: 1.18rem;
   color: var(--ink);
   letter-spacing: -0.01em;
 }
 
 .context-date {
-  font-size: 0.88rem;
+  font-size: 0.8rem;
   color: var(--muted);
   font-weight: 500;
 }
 
 .context-weather-inline {
-  font-size: 0.82rem;
+  font-size: 0.76rem;
   color: var(--muted);
   line-height: 1.4;
   overflow-wrap: anywhere;
@@ -1364,7 +1374,7 @@ h3 {
 .check-in-card {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.7rem;
 }
 
 .check-in-header {
@@ -1374,7 +1384,7 @@ h3 {
 }
 
 .check-in-prompt {
-  font-size: 0.9rem;
+  font-size: 0.92rem;
   color: var(--ink);
   margin: 0;
 }
@@ -1384,7 +1394,7 @@ h3 {
   display: flex;
   overflow-x: auto;
   gap: 0;
-  padding: 0.4rem;
+  padding: 0.32rem;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--line);
   border-radius: 16px;
@@ -1393,11 +1403,11 @@ h3 {
 
 .phase-map-segment {
   flex: 1;
-  min-width: 6.2rem;
+  min-width: 6rem;
   display: flex;
   flex-direction: column;
   gap: 0.18rem;
-  padding: 0.55rem 0.65rem;
+  padding: 0.5rem 0.58rem;
   border-radius: 12px;
   background: transparent;
   color: var(--muted);
@@ -1444,7 +1454,7 @@ h3 {
 }
 
 .phase-map-hours {
-  font-size: 0.68rem;
+  font-size: 0.64rem;
   font-weight: 600;
   letter-spacing: 0.04em;
   color: var(--muted);
@@ -1462,7 +1472,7 @@ h3 {
 .phase-map-card > *:nth-child(5).active .phase-map-hours { color: var(--phase-5); }
 
 .phase-map-name {
-  font-size: 0.84rem;
+  font-size: 0.8rem;
   font-weight: 700;
   display: flex;
   align-items: flex-start;
@@ -1512,7 +1522,7 @@ h3 {
 
 /* Phase map task badge */
 .phase-map-badge {
-  font-size: 0.68rem;
+  font-size: 0.64rem;
   background: rgba(255, 255, 255, 0.07);
   color: var(--muted);
   border-radius: 999px;
@@ -1553,18 +1563,21 @@ h3 {
 }
 
 .day-check-options {
-  display: flex;
-  gap: 0.4rem;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(6.8rem, 1fr));
+  gap: 0.45rem;
 }
 
 .day-check-btn {
-  font-size: 0.84rem;
+  font-size: 0.82rem;
   font-weight: 600;
-  padding: 0.4rem 0.85rem;
+  width: 100%;
+  min-height: 2.35rem;
+  padding: 0.42rem 0.55rem;
   background: rgba(255, 255, 255, 0.06);
   color: var(--ink);
   border: 1px solid var(--line);
+  text-align: center;
 }
 
 .day-check-btn:hover {
@@ -1922,7 +1935,7 @@ h3 {
 
 @media (min-width: 700px) {
   .app-shell {
-    padding: 1rem 1.5rem;
+    padding: 1rem 1.5rem 1.3rem;
   }
 
   .card {
@@ -1931,10 +1944,29 @@ h3 {
   }
 
   .topbar-card {
+    display: flex;
     align-items: center;
+    justify-content: space-between;
     flex-wrap: nowrap;
     position: sticky;
     top: 0.5rem;
+    gap: 0.8rem;
+    padding: 1rem;
+    border-radius: 22px;
+  }
+
+  .topbar-actions {
+    gap: 0.5rem;
+  }
+
+  .topbar-actions .save-dot {
+    display: inline-flex;
+  }
+
+  .profile-trigger {
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: 1rem;
   }
 
   .button-row > button {
@@ -1989,6 +2021,66 @@ h3 {
 
   .phase-controls {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .context-strip {
+    padding: 0.85rem 1rem;
+  }
+
+  .context-strip-top {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem 1rem;
+  }
+
+  .context-strip-top > div {
+    gap: 0.28rem;
+  }
+
+  .context-greeting {
+    font-size: 1.3rem;
+  }
+
+  .context-date {
+    font-size: 0.88rem;
+  }
+
+  .context-weather-inline {
+    font-size: 0.82rem;
+  }
+
+  .day-check-options {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .day-check-btn {
+    width: auto;
+    min-height: 2.25rem;
+    padding: 0.4rem 0.85rem;
+  }
+
+  .phase-map-card {
+    padding: 0.4rem;
+  }
+
+  .phase-map-segment {
+    min-width: 6.2rem;
+    padding: 0.55rem 0.65rem;
+  }
+
+  .phase-map-hours {
+    font-size: 0.68rem;
+  }
+
+  .phase-map-name {
+    font-size: 0.84rem;
+  }
+
+  .phase-map-badge {
+    font-size: 0.68rem;
   }
 
   .exercise-add-form {


### PR DESCRIPTION
## Summary
- tighten mobile top bar layout so the profile control remains visible and the header consumes less vertical space
- improve mobile readability hierarchy in the context strip (greeting, date, and weather metadata)
- convert check-in choices to a responsive button grid with larger touch targets
- add safer bottom padding for iOS browser chrome/safe-area overlap and rebalance compact card spacing

## Validation
- npm run build
- npm test
