### PR TITLE
Admin user management: create/delete accounts and reset passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,67 @@
 # Focus Flow
 
-Small local prototype for an ADHD-friendly task app.
+Focus Flow is a local-first ADHD-friendly day planner built around phases, low-friction task flow, and supportive context prompts.
 
-## Current Scope
+## What It Does
 
-- Break the day into phases such as morning, afternoon, and evening.
-- Customize phase names and default lengths.
-- Start a phase with a quick mind check and lightweight guidance.
-- Work through an ordered checklist for the active phase.
-- Start nested task timers inside a running phase.
-- Create local user accounts with email and password.
-- Persist each user's settings and routines in a local SQLite database.
+### User features
 
-## Local Run
+- Phase-based planner with default morning/afternoon/evening flow.
+- Custom phase structure: rename phases, adjust default duration, insert phases anywhere, and add phases at the end.
+- Daily check-in with wake-time, body-state, and attention-state prompts.
+- Mind context card with weather, UV, sunrise/sunset, and circadian framing.
+- Ordered task lists inside each phase.
+- Task actions: check/uncheck, edit details, delete, move between phases.
+- Repeating template tasks and one-off tasks.
+- Nested timers (phase timer + optional per-task timers).
+- Exercise section for adding and moving exercise tasks between phases.
+- Profile controls for goals, timezone/location refresh, and optional cycle tracking.
 
-### Docker
+### Admin features
+
+- Feature flag controls:
+  - `daily_check_in`
+  - `mind_context`
+  - `cycle_tracking`
+  - `task_timers`
+  - `proactive_suggestions`
+- User search and account inspection (sessions, planner summary, auth lock state).
+- User lifecycle controls:
+  - create users (local auth mode)
+  - reset user passwords (local auth mode)
+  - delete users
+  - suspend/reactivate accounts
+  - revoke sessions
+  - unlock login lock state
+- Testing controls:
+  - reset planner state
+  - seed demo planner state
+  - clear planner activity
+- Recent audit event log for operational visibility.
+
+## Architecture
+
+- Frontend: React + Vite (`src/`)
+- API: Express (`server/createApp.js`, `server/server.js`)
+- Storage: SQLite via `better-sqlite3` (`data/focus-flow.db`)
+- Auth: local password mode by default, with a managed-auth switch (`server/auth.js`)
+
+## Run Locally
+
+### Prerequisites
+
+- Node 20+
+- Docker Desktop (if using Docker workflow)
+
+### Docker (recommended for local testing)
 
 ```bash
 docker compose up --build
 ```
 
-App URL: [http://localhost:3000](http://localhost:3000)
-
-LAN test URL: `http://<your-local-ip>:3000`
-
-API URL: `http://localhost:3001`
+- App UI: [http://localhost:3000](http://localhost:3000)
+- API: [http://localhost:3001](http://localhost:3001)
+- LAN test URL: `http://<your-local-ip>:3000`
 
 ### Without Docker
 
@@ -33,45 +70,84 @@ npm install
 npm run dev
 ```
 
-## Admin Access
+## First-Time User Flow
 
-- Local admin access is controlled by the `ADMIN_EMAILS` environment variable.
+1. Register with name/email/password.
+2. Complete onboarding:
+   - choose goals
+   - optionally configure cycle tracking
+   - set phase durations
+3. Start from Planner and complete check-in.
+4. Start the active phase and work tasks with optional nested timers.
+5. Use the top-right profile menu for Profile, Settings, Admin (if admin), and Dashboard navigation.
+
+## Admin Setup And Usage
+
+### How admin role is assigned
+
+- `ADMIN_EMAILS` env var can auto-elevate matching emails.
 - Example: `ADMIN_EMAILS=you@example.com,teammate@example.com`
-- Matching users are elevated to the `admin` role on register/login/session refresh.
-- If no admin exists yet in local auth mode, a signed-in user can claim admin access from the Profile page.
-- Admins get an in-app Admin page for:
-  - toggling feature flags
-  - viewing recent audit/error events
-  - searching users
-  - inspecting user state and active sessions
-  - suspending/reactivating accounts
-  - revoking sessions
-  - resetting planner state
-  - seeding demo planner data
-  - clearing planner activity (while keeping the account)
+- In local auth mode, if no admin exists yet, a signed-in user can claim admin from Profile.
 
-## Local Data
+### Admin safeguards
 
-- SQLite database path: `data/focus-flow.db`
-- Session state uses an HTTP-only cookie in the browser.
-- User records now track `auth_provider`, `auth_subject`, `account_status`, and `last_login_at` so local password auth can be swapped for managed auth later without rewriting the user model.
-- Local runtime artifacts should stay out of git and out of Docker build context.
+- You cannot delete your own account.
+- You cannot delete the last remaining admin account.
+- Password reset and admin-created local users are disabled when `AUTH_MODE=managed`.
 
-## Auth Mode
+## Environment Variables
 
-- `AUTH_MODE=local` is the default for local development.
-- `AUTH_MODE=managed` disables password sign-in and registration in the UI/API so the app can be wired to a managed identity provider later.
-- `MANAGED_AUTH_PROVIDER` is an optional label shown in the UI/admin panel when managed mode is enabled.
+- `AUTH_MODE`
+  - `local` (default): email/password registration and sign-in enabled.
+  - `managed`: disables local password registration/login/reset flows.
+- `MANAGED_AUTH_PROVIDER`
+  - optional label shown in UI/admin when managed mode is active.
+- `ADMIN_EMAILS`
+  - comma-separated list of emails to auto-grant admin.
+- `COOKIE_SECURE`
+  - `true` to mark auth cookie as secure (recommended for HTTPS deployments).
+- `LOGIN_FAILURE_LIMIT`
+  - number of failed password attempts before lock (default `5`).
+- `LOGIN_LOCK_MS`
+  - lock window duration in milliseconds (default `900000`, 15 minutes).
+
+## Data And Persistence
+
+- DB file: `data/focus-flow.db`
+- Sessions use HTTP-only cookies.
+- User settings, phase/task state, and admin audit events are persisted in SQLite.
+
+## Development Commands
+
+```bash
+npm run dev
+npm run build
+npm test
+```
+
+## Troubleshooting
+
+### Login or API calls fail after container restart
+
+If you see proxy errors from `:3000` to `:3001`, or logs like `better_sqlite3.node: Exec format error`, reset the Docker runtime volumes and rebuild:
+
+```bash
+docker compose down --volumes
+docker compose up --build
+```
+
+### Account lock after repeated bad password attempts
+
+- Wait for the lock window to expire, or
+- Use Admin -> Users -> `Unlock login` on that account.
+
+### No admin account available
+
+- In local auth mode, sign in and use Profile -> `Claim admin access` if bootstrap is available.
+- Or set `ADMIN_EMAILS` and sign in with a matching account.
 
 ## Change Management
 
-- `main` holds the latest stable local baseline.
-- Use short-lived branches for work, prefixed with `codex/` for agent-created branches.
-- Keep commits focused on one functional change at a time.
-- Run `npm run build` before committing UI changes.
-
-## Next Likely Steps
-
-- Add a real backend and database for multi-device persistence.
-- Add reusable routine templates and recurring defaults.
-- Add a better visual phase flow and timer history.
+- `main` is the stable baseline branch.
+- Use short-lived feature branches (agent branches are prefixed with `codex/`).
+- Prefer PR-based changes.

--- a/server/createApp.js
+++ b/server/createApp.js
@@ -202,6 +202,12 @@ export function createApp({
       }));
   }
 
+  function countAdminUsers() {
+    return Number(
+      db.prepare("SELECT COUNT(*) AS count FROM users WHERE role = 'admin'").get()?.count ?? 0
+    );
+  }
+
   function activeSessionCountForUser(userId, nowIso = new Date().toISOString()) {
     const row = db
       .prepare(
@@ -237,9 +243,7 @@ export function createApp({
   }
 
   function authResponseForUser(user, settingsJson = user.settings_json) {
-    const adminCount = Number(
-      db.prepare("SELECT COUNT(*) AS count FROM users WHERE role = 'admin'").get()?.count ?? 0
-    );
+    const adminCount = countAdminUsers();
     return {
       user: publicUser(user),
       settings: parseStoredSettings(settingsJson),
@@ -785,6 +789,73 @@ export function createApp({
     res.json({ users });
   });
 
+  app.post('/api/admin/users', requireAuth, requireAdmin, (req, res) => {
+    if (getAuthConfig().mode !== 'local') {
+      return res.status(403).json({ error: 'Admin user creation is disabled for managed auth mode.' });
+    }
+
+    const email = normalizeEmail(req.body?.email);
+    const password = String(req.body?.password ?? '');
+    const displayName = String(req.body?.displayName ?? '').trim();
+    const role = String(req.body?.role ?? 'user').trim().toLowerCase();
+
+    if (!email || !password || !displayName) {
+      return res.status(400).json({ error: 'Name, email, and password are required.' });
+    }
+    if (!['user', 'admin'].includes(role)) {
+      return res.status(400).json({ error: 'role must be "user" or "admin".' });
+    }
+    if (password.length < 8) {
+      return res.status(400).json({ error: 'Password must be at least 8 characters.' });
+    }
+
+    const existing = db.prepare('SELECT id FROM users WHERE email = ?').get(email);
+    if (existing) {
+      return res.status(409).json({ error: 'An account already exists for that email.' });
+    }
+
+    const createdAt = new Date().toISOString();
+    const userId = crypto.randomUUID();
+    const identity = buildLocalIdentity(email);
+    db.prepare(
+      `INSERT INTO users (
+        id, email, password_hash, display_name, role, auth_provider, auth_subject, account_status, settings_json, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      userId,
+      email,
+      hashPassword(password),
+      displayName,
+      role,
+      identity.authProvider,
+      identity.authSubject,
+      'active',
+      JSON.stringify(buildDefaultState()),
+      createdAt
+    );
+
+    const createdUser = db
+      .prepare(
+        'SELECT id, email, display_name, role, auth_provider, account_status, failed_login_attempts, last_failed_login_at, locked_until FROM users WHERE id = ?'
+      )
+      .get(userId);
+
+    writeAuditEvent({
+      eventType: 'admin.user_created',
+      level: 'warn',
+      actorUserId: req.user.id,
+      targetUserId: userId,
+      requestId: req.requestId,
+      message: `User created by admin: ${email}`,
+      metadata: { role, createdAt },
+    });
+
+    return res.status(201).json({
+      ok: true,
+      user: publicUser(createdUser),
+    });
+  });
+
   app.get('/api/admin/users/:userId', requireAuth, requireAdmin, (req, res) => {
     const targetUserId = String(req.params.userId ?? '').trim();
     const nowIso = new Date().toISOString();
@@ -825,6 +896,101 @@ export function createApp({
       activeSessionCount: activeSessionCountForUser(targetUserId, nowIso),
       sessions,
       plannerStateSummary: plannerStateSummaryForSettings(target.settings_json),
+    });
+  });
+
+  app.post('/api/admin/users/:userId/reset-password', requireAuth, requireAdmin, (req, res) => {
+    if (getAuthConfig().mode !== 'local') {
+      return res.status(403).json({ error: 'Password reset is disabled for managed auth mode.' });
+    }
+
+    const targetUserId = String(req.params.userId ?? '').trim();
+    const password = String(req.body?.password ?? '');
+    if (password.length < 8) {
+      return res.status(400).json({ error: 'Password must be at least 8 characters.' });
+    }
+
+    const target = db
+      .prepare(
+        'SELECT id, email, display_name, role, auth_provider, account_status, failed_login_attempts, last_failed_login_at, locked_until, password_hash FROM users WHERE id = ?'
+      )
+      .get(targetUserId);
+    if (!target) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+    if (!canUsePasswordAuth(target)) {
+      return res.status(400).json({ error: 'Password reset is only available for local-auth users.' });
+    }
+
+    db.prepare('UPDATE users SET password_hash = ? WHERE id = ?').run(hashPassword(password), targetUserId);
+    clearLoginFailures(targetUserId);
+
+    let revokedSessions = 0;
+    let preservedCurrentSession = false;
+    if (targetUserId === req.user.id) {
+      const result = db.prepare('DELETE FROM sessions WHERE user_id = ? AND token <> ?').run(targetUserId, req.sessionToken);
+      revokedSessions = Number(result.changes ?? 0);
+      preservedCurrentSession = true;
+    } else {
+      const result = db.prepare('DELETE FROM sessions WHERE user_id = ?').run(targetUserId);
+      revokedSessions = Number(result.changes ?? 0);
+    }
+
+    writeAuditEvent({
+      eventType: 'admin.user_password_reset',
+      level: 'warn',
+      actorUserId: req.user.id,
+      targetUserId,
+      requestId: req.requestId,
+      message: `User password reset by admin: ${target.email}`,
+      metadata: { revokedSessions, preservedCurrentSession },
+    });
+
+    return res.json({
+      ok: true,
+      revokedSessions,
+      preservedCurrentSession,
+      user: publicUser(target),
+    });
+  });
+
+  app.delete('/api/admin/users/:userId', requireAuth, requireAdmin, (req, res) => {
+    const targetUserId = String(req.params.userId ?? '').trim();
+    if (!targetUserId) {
+      return res.status(400).json({ error: 'User ID is required.' });
+    }
+    if (targetUserId === req.user.id) {
+      return res.status(400).json({ error: 'Admin users cannot delete their own account.' });
+    }
+
+    const target = db
+      .prepare(
+        'SELECT id, email, display_name, role, auth_provider, account_status, failed_login_attempts, last_failed_login_at, locked_until FROM users WHERE id = ?'
+      )
+      .get(targetUserId);
+    if (!target) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+    if (target.role === 'admin' && countAdminUsers() <= 1) {
+      return res.status(400).json({ error: 'Cannot delete the last admin account.' });
+    }
+
+    writeAuditEvent({
+      eventType: 'admin.user_deleted',
+      level: 'warn',
+      actorUserId: req.user.id,
+      targetUserId,
+      requestId: req.requestId,
+      message: `User deleted by admin: ${target.email}`,
+      metadata: { role: target.role },
+    });
+
+    db.prepare('DELETE FROM users WHERE id = ?').run(targetUserId);
+
+    return res.json({
+      ok: true,
+      deletedUserId: targetUserId,
+      user: publicUser(target),
     });
   });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,6 +107,9 @@ export default function App() {
     seedDemoState,
     clearUserActivity,
     unlockUserAuth,
+    createAdminUser,
+    resetUserPassword,
+    deleteUserAccount,
   } = useAdminData({
     user,
     siteView,
@@ -856,6 +859,9 @@ export default function App() {
             seedDemoState={seedDemoState}
             clearUserActivity={clearUserActivity}
             unlockUserAuth={unlockUserAuth}
+            createAdminUser={createAdminUser}
+            resetUserPassword={resetUserPassword}
+            deleteUserAccount={deleteUserAccount}
           />
         )}
 

--- a/src/hooks/useAdminData.js
+++ b/src/hooks/useAdminData.js
@@ -206,6 +206,75 @@ export function useAdminData({ user, siteView, onFeatureFlagsChange, refreshAuth
     }
   }
 
+  async function createAdminUser(payload) {
+    setAdminStatus('');
+    setAdminLoading(true);
+    try {
+      const data = await api('/api/admin/users', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      setAdminStatus(`Created user ${data.user?.email ?? payload.email}.`);
+      await Promise.all([refreshAdminSummary(), searchAdminUsers()]);
+      return true;
+    } catch (error) {
+      setAdminStatus(error.message);
+      return false;
+    } finally {
+      setAdminLoading(false);
+    }
+  }
+
+  async function resetUserPassword(targetUserId, password) {
+    setAdminStatus('');
+    setAdminLoading(true);
+    try {
+      const data = await api(`/api/admin/users/${encodeURIComponent(targetUserId)}/reset-password`, {
+        method: 'POST',
+        body: JSON.stringify({ password }),
+      });
+      setAdminStatus(
+        data.preservedCurrentSession
+          ? `Password reset. Revoked ${data.revokedSessions} other sessions and preserved your current session.`
+          : `Password reset. Revoked ${data.revokedSessions} active sessions.`
+      );
+      await Promise.all([refreshAdminSummary(), searchAdminUsers()]);
+      if (selectedAdminUser?.user?.id === targetUserId) {
+        await inspectUser(targetUserId);
+      }
+      if (data.preservedCurrentSession && targetUserId === user?.id) {
+        await refreshAuthenticatedSession?.();
+      }
+      return true;
+    } catch (error) {
+      setAdminStatus(error.message);
+      return false;
+    } finally {
+      setAdminLoading(false);
+    }
+  }
+
+  async function deleteUserAccount(targetUserId) {
+    setAdminStatus('');
+    setAdminLoading(true);
+    try {
+      const data = await api(`/api/admin/users/${encodeURIComponent(targetUserId)}`, {
+        method: 'DELETE',
+      });
+      setAdminStatus(`Deleted user ${data.user?.email ?? targetUserId}.`);
+      if (selectedAdminUser?.user?.id === targetUserId) {
+        setSelectedAdminUser(null);
+      }
+      await Promise.all([refreshAdminSummary(), searchAdminUsers()]);
+      return true;
+    } catch (error) {
+      setAdminStatus(error.message);
+      return false;
+    } finally {
+      setAdminLoading(false);
+    }
+  }
+
   useEffect(() => {
     if (siteView === 'admin' && user?.role === 'admin') {
       refreshAdminSummary();
@@ -232,5 +301,8 @@ export function useAdminData({ user, siteView, onFeatureFlagsChange, refreshAuth
     seedDemoState,
     clearUserActivity,
     unlockUserAuth,
+    createAdminUser,
+    resetUserPassword,
+    deleteUserAccount,
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2186,6 +2186,7 @@ h3 {
 .admin-user-row,
 .admin-event-topline,
 .admin-user-search,
+.admin-user-create-form,
 .admin-metrics {
   display: flex;
   gap: 0.75rem;
@@ -2230,6 +2231,17 @@ h3 {
 .admin-user-search input {
   flex: 1;
   min-width: 0;
+}
+
+.admin-user-create-form input,
+.admin-user-create-form select {
+  flex: 1 1 10rem;
+  min-width: 0;
+}
+
+.admin-password-input {
+  min-width: 9rem;
+  flex: 1 1 10rem;
 }
 
 @media (max-width: 640px) {

--- a/src/views/AdminView.jsx
+++ b/src/views/AdminView.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 export function AdminView({
   user,
   adminSummary,
@@ -18,12 +20,59 @@ export function AdminView({
   seedDemoState,
   clearUserActivity,
   unlockUserAuth,
+  createAdminUser,
+  resetUserPassword,
+  deleteUserAccount,
 }) {
+  const [createUserDraft, setCreateUserDraft] = useState({
+    displayName: '',
+    email: '',
+    password: '',
+    role: 'user',
+  });
+  const [passwordDrafts, setPasswordDrafts] = useState({});
+  const isLocalAuth = (adminSummary.auth?.mode ?? 'local') === 'local';
+
   function confirmAndRun(message, action) {
     if (!window.confirm(message)) {
       return;
     }
-    action();
+    void action();
+  }
+
+  async function onCreateUserSubmit(event) {
+    event.preventDefault();
+    const payload = {
+      displayName: createUserDraft.displayName.trim(),
+      email: createUserDraft.email.trim(),
+      password: createUserDraft.password,
+      role: createUserDraft.role,
+    };
+    const created = await createAdminUser(payload);
+    if (!created) {
+      return;
+    }
+    setCreateUserDraft({
+      displayName: '',
+      email: '',
+      password: '',
+      role: 'user',
+    });
+  }
+
+  async function onResetPassword(adminUser) {
+    const password = String(passwordDrafts[adminUser.id] ?? '');
+    if (password.length < 8) {
+      window.alert('Password must be at least 8 characters.');
+      return;
+    }
+
+    confirmAndRun(`Reset password for ${adminUser.email}?`, async () => {
+      const changed = await resetUserPassword(adminUser.id, password);
+      if (changed) {
+        setPasswordDrafts((current) => ({ ...current, [adminUser.id]: '' }));
+      }
+    });
   }
 
   return (
@@ -116,6 +165,46 @@ export function AdminView({
           />
           <button type="submit" className="secondary">Search</button>
         </form>
+        {isLocalAuth && (
+          <form className="admin-user-create-form" onSubmit={onCreateUserSubmit}>
+            <input
+              type="text"
+              placeholder="Display name"
+              value={createUserDraft.displayName}
+              onChange={(event) => setCreateUserDraft((current) => ({ ...current, displayName: event.target.value }))}
+              autoComplete="name"
+              required
+            />
+            <input
+              type="email"
+              placeholder="Email"
+              value={createUserDraft.email}
+              onChange={(event) => setCreateUserDraft((current) => ({ ...current, email: event.target.value }))}
+              autoComplete="email"
+              required
+            />
+            <input
+              type="password"
+              placeholder="Temporary password"
+              value={createUserDraft.password}
+              onChange={(event) => setCreateUserDraft((current) => ({ ...current, password: event.target.value }))}
+              autoComplete="new-password"
+              minLength={8}
+              required
+            />
+            <select
+              value={createUserDraft.role}
+              onChange={(event) => setCreateUserDraft((current) => ({ ...current, role: event.target.value }))}
+            >
+              <option value="user">User</option>
+              <option value="admin">Admin</option>
+            </select>
+            <button type="submit" className="secondary">Create user</button>
+          </form>
+        )}
+        {!isLocalAuth && (
+          <p className="muted-copy">Managed auth mode is enabled. User creation and password reset are unavailable here.</p>
+        )}
         <div className="admin-user-list">
           {adminUsers.map((adminUser) => (
             <div key={adminUser.id} className="admin-user-row">
@@ -214,6 +303,37 @@ export function AdminView({
                   }
                 >
                   Clear activity
+                </button>
+                {isLocalAuth && (
+                  <>
+                    <input
+                      type="password"
+                      placeholder="New password"
+                      value={passwordDrafts[adminUser.id] ?? ''}
+                      onChange={(event) => setPasswordDrafts((current) => ({ ...current, [adminUser.id]: event.target.value }))}
+                      autoComplete="new-password"
+                      minLength={8}
+                      className="admin-password-input"
+                    />
+                    <button
+                      className="ghost small"
+                      onClick={() => onResetPassword(adminUser)}
+                    >
+                      Set password
+                    </button>
+                  </>
+                )}
+                <button
+                  className="ghost small"
+                  disabled={adminUser.id === user.id}
+                  onClick={() =>
+                    confirmAndRun(
+                      `Delete account ${adminUser.email}? This cannot be undone.`,
+                      () => deleteUserAccount(adminUser.id)
+                    )
+                  }
+                >
+                  Delete user
                 </button>
               </div>
             </div>

--- a/test/api-routes.test.js
+++ b/test/api-routes.test.js
@@ -615,3 +615,201 @@ test('admin can seed demo state and clear user activity', async () => {
     await server.close();
   }
 });
+
+test('admin can create users and rejects duplicates', async () => {
+  const server = await startTestServer({
+    name: 'focusflow-admin-create-user',
+    adminEmails: ['admin@example.com'],
+  });
+  try {
+    const adminRegistration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Admin',
+        email: 'admin@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const adminCookie = readCookie(adminRegistration.response.headers.get('set-cookie'));
+
+    const createUser = await server.request('/api/admin/users', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: adminCookie,
+      },
+      body: JSON.stringify({
+        displayName: 'Casey',
+        email: 'casey@example.com',
+        password: 'temporarypass',
+        role: 'user',
+      }),
+    });
+    assert.equal(createUser.response.status, 201);
+    assert.equal(createUser.body.ok, true);
+    assert.equal(createUser.body.user.email, 'casey@example.com');
+    assert.equal(createUser.body.user.role, 'user');
+
+    const createdLogin = await server.request('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'casey@example.com',
+        password: 'temporarypass',
+      }),
+    });
+    assert.equal(createdLogin.response.status, 200);
+
+    const createDuplicate = await server.request('/api/admin/users', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: adminCookie,
+      },
+      body: JSON.stringify({
+        displayName: 'Casey 2',
+        email: 'casey@example.com',
+        password: 'anotherpass',
+        role: 'admin',
+      }),
+    });
+    assert.equal(createDuplicate.response.status, 409);
+  } finally {
+    await server.close();
+  }
+});
+
+test('admin can reset a user password and revoke active sessions', async () => {
+  const server = await startTestServer({
+    name: 'focusflow-admin-reset-password',
+    adminEmails: ['admin@example.com'],
+  });
+  try {
+    const adminRegistration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Admin',
+        email: 'admin@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const adminCookie = readCookie(adminRegistration.response.headers.get('set-cookie'));
+
+    const userRegistration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Jordan',
+        email: 'jordan@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const userCookie = readCookie(userRegistration.response.headers.get('set-cookie'));
+    const userId = userRegistration.body.user.id;
+
+    const resetPassword = await server.request(`/api/admin/users/${userId}/reset-password`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        cookie: adminCookie,
+      },
+      body: JSON.stringify({ password: 'brandnewpassword' }),
+    });
+    assert.equal(resetPassword.response.status, 200);
+    assert.equal(resetPassword.body.ok, true);
+    assert.equal(resetPassword.body.revokedSessions, 1);
+    assert.equal(resetPassword.body.preservedCurrentSession, false);
+
+    const revokedSession = await server.request('/api/auth/session', {
+      headers: { cookie: userCookie },
+    });
+    assert.equal(revokedSession.response.status, 401);
+
+    const oldPasswordLogin = await server.request('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'jordan@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    assert.equal(oldPasswordLogin.response.status, 401);
+
+    const newPasswordLogin = await server.request('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'jordan@example.com',
+        password: 'brandnewpassword',
+      }),
+    });
+    assert.equal(newPasswordLogin.response.status, 200);
+  } finally {
+    await server.close();
+  }
+});
+
+test('admin can delete users but cannot delete their own account', async () => {
+  const server = await startTestServer({
+    name: 'focusflow-admin-delete-user',
+    adminEmails: ['admin@example.com'],
+  });
+  try {
+    const adminRegistration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Admin',
+        email: 'admin@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const adminCookie = readCookie(adminRegistration.response.headers.get('set-cookie'));
+    const adminId = adminRegistration.body.user.id;
+
+    const userRegistration = await server.request('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: 'Taylor',
+        email: 'taylor@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    const userCookie = readCookie(userRegistration.response.headers.get('set-cookie'));
+    const userId = userRegistration.body.user.id;
+
+    const selfDelete = await server.request(`/api/admin/users/${adminId}`, {
+      method: 'DELETE',
+      headers: { cookie: adminCookie },
+    });
+    assert.equal(selfDelete.response.status, 400);
+
+    const deleteUser = await server.request(`/api/admin/users/${userId}`, {
+      method: 'DELETE',
+      headers: { cookie: adminCookie },
+    });
+    assert.equal(deleteUser.response.status, 200);
+    assert.equal(deleteUser.body.ok, true);
+    assert.equal(deleteUser.body.deletedUserId, userId);
+
+    const deletedSession = await server.request('/api/auth/session', {
+      headers: { cookie: userCookie },
+    });
+    assert.equal(deletedSession.response.status, 401);
+
+    const deletedUserLogin = await server.request('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: 'taylor@example.com',
+        password: 'longenoughpassword',
+      }),
+    });
+    assert.equal(deletedUserLogin.response.status, 401);
+  } finally {
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add admin API endpoints to create users, reset user passwords, and delete users
- add admin UI controls for create user, set password, and delete user
- enforce safety checks (no self-delete, local-auth-only password operations, session revocation on password reset)
- extend API tests for create/reset/delete user flows and regressions

## Verification
- npm test
- npm run build
